### PR TITLE
fix(security): scope alert webhook actions by org

### DIFF
--- a/observal-server/api/routes/alert.py
+++ b/observal-server/api/routes/alert.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 import secrets
@@ -38,6 +39,20 @@ def _validate_webhook_url(url: str) -> None:
         raise HTTPException(400, "webhook_url must use http or https")
     if is_private_url(url):
         raise HTTPException(400, "webhook_url must not point to private/internal networks")
+
+
+async def _get_alert_for_user(db: AsyncSession, alert_id: uuid.UUID, current_user: User) -> AlertRule:
+    """Load an alert and enforce the existing org boundary policy."""
+    rule = await db.get(AlertRule, alert_id)
+    if not rule:
+        raise HTTPException(404, "Alert rule not found")
+
+    if current_user.org_id is not None:
+        creator = (await db.execute(select(User).where(User.id == rule.created_by))).scalar_one_or_none()
+        if not creator or creator.org_id != current_user.org_id:
+            raise HTTPException(404, "Alert rule not found")
+
+    return rule
 
 
 @router.get("", response_model=list[AlertRuleResponse])
@@ -92,14 +107,7 @@ async def update_alert(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("alert update")
-    rule = await db.get(AlertRule, alert_id)
-    if not rule:
-        raise HTTPException(404, "Alert rule not found")
-    # Org-scope check: ensure the alert belongs to the user's org
-    if current_user.org_id is not None:
-        creator = (await db.execute(select(User).where(User.id == rule.created_by))).scalar_one_or_none()
-        if not creator or creator.org_id != current_user.org_id:
-            raise HTTPException(404, "Alert rule not found")
+    rule = await _get_alert_for_user(db, alert_id, current_user)
     is_admin_or_above = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if rule.created_by != current_user.id and not is_admin_or_above:
         raise HTTPException(403, "Not authorized to modify this alert rule")
@@ -120,14 +128,7 @@ async def delete_alert(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("alert delete")
-    rule = await db.get(AlertRule, alert_id)
-    if not rule:
-        raise HTTPException(404, "Alert rule not found")
-    # Org-scope check: ensure the alert belongs to the user's org
-    if current_user.org_id is not None:
-        creator = (await db.execute(select(User).where(User.id == rule.created_by))).scalar_one_or_none()
-        if not creator or creator.org_id != current_user.org_id:
-            raise HTTPException(404, "Alert rule not found")
+    rule = await _get_alert_for_user(db, alert_id, current_user)
     is_admin_or_above = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if rule.created_by != current_user.id and not is_admin_or_above:
         raise HTTPException(403, "Not authorized to delete this alert rule")
@@ -145,14 +146,7 @@ async def get_alert_history(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("fetching alert history for {} (limit={})", alert_id, limit)
-    rule = await db.get(AlertRule, alert_id)
-    if not rule:
-        raise HTTPException(404, "Alert rule not found")
-    # Org-scope check: ensure the alert belongs to the user's org
-    if current_user.org_id is not None:
-        creator = (await db.execute(select(User).where(User.id == rule.created_by))).scalar_one_or_none()
-        if not creator or creator.org_id != current_user.org_id:
-            raise HTTPException(404, "Alert rule not found")
+    rule = await _get_alert_for_user(db, alert_id, current_user)
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if rule.created_by != current_user.id and not is_admin:
         raise HTTPException(403, "Not authorized")
@@ -177,9 +171,7 @@ async def rotate_webhook_secret(
 ):
     """Rotate the webhook signing secret for an alert rule. Admin only."""
     optic.debug("rotating webhook secret for alert {}", alert_id)
-    rule = await db.get(AlertRule, alert_id)
-    if not rule:
-        raise HTTPException(404, "Alert rule not found")
+    rule = await _get_alert_for_user(db, alert_id, current_user)
 
     from datetime import UTC, datetime
 
@@ -200,15 +192,9 @@ async def reveal_webhook_secret(
 ):
     """Reveal the full webhook secret. Admin only, audit-logged."""
     optic.debug("revealing webhook secret for alert {}", alert_id)
-    import logging
+    rule = await _get_alert_for_user(db, alert_id, current_user)
 
-    logger = logging.getLogger(__name__)
-
-    rule = await db.get(AlertRule, alert_id)
-    if not rule:
-        raise HTTPException(404, "Alert rule not found")
-
-    logger.info(
+    optic.info(
         "Webhook secret revealed: alert_rule_id={} by user_id={}",
         alert_id,
         current_user.id,
@@ -224,9 +210,7 @@ async def test_webhook(
 ):
     """Send a test webhook to the configured URL. Owner or admin."""
     optic.debug("sending test webhook for alert {}", alert_id)
-    rule = await db.get(AlertRule, alert_id)
-    if not rule:
-        raise HTTPException(404, "Alert rule not found")
+    rule = await _get_alert_for_user(db, alert_id, current_user)
 
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if rule.created_by != current_user.id and not is_admin:

--- a/tests/test_alert_evaluator.py
+++ b/tests/test_alert_evaluator.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for alert evaluation engine, SSRF protection, and webhook delivery."""
@@ -390,6 +391,190 @@ class TestAlertRouteSSRF:
 
         with patch("api.routes.alert.is_private_url", return_value=False):
             _validate_webhook_url("https://hooks.slack.com/services/T00/B00/xxx")
+
+
+def _alert_route_user(*, role="admin", org_id=None, user_id=None):
+    from models.user import UserRole
+
+    user = MagicMock()
+    user.id = user_id or uuid.uuid4()
+    user.role = getattr(UserRole, role)
+    user.org_id = org_id
+    return user
+
+
+def _alert_route_rule(*, created_by=None, webhook_url="https://example.com/hook"):
+    rule = MagicMock()
+    rule.id = uuid.uuid4()
+    rule.name = "Latency"
+    rule.metric = "latency_p99"
+    rule.threshold = 1000.0
+    rule.condition = "above"
+    rule.target_type = "all"
+    rule.target_id = ""
+    rule.webhook_url = webhook_url
+    rule.webhook_secret = "old-secret-value"
+    rule.created_by = created_by or uuid.uuid4()
+    rule.status = "active"
+    rule.last_triggered = None
+    rule.created_at = datetime.now(UTC)
+    return rule
+
+
+def _alert_route_db(rule, creator=None):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = creator
+
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=rule)
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+class TestAlertOrgScopedRoutes:
+    @pytest.mark.asyncio
+    async def test_missing_alert_update_returns_404(self):
+        from api.routes.alert import update_alert
+        from schemas.alert import AlertRuleUpdate
+
+        current_user = _alert_route_user(org_id=uuid.uuid4())
+        db = _alert_route_db(None)
+
+        with pytest.raises(Exception) as exc_info:
+            await update_alert(uuid.uuid4(), AlertRuleUpdate(status="paused"), db, current_user)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_same_org_owner_can_delete_alert(self):
+        from api.routes.alert import delete_alert
+
+        org_id = uuid.uuid4()
+        owner_id = uuid.uuid4()
+        current_user = _alert_route_user(role="user", org_id=org_id, user_id=owner_id)
+        creator = _alert_route_user(role="user", org_id=org_id, user_id=owner_id)
+        rule = _alert_route_rule(created_by=owner_id)
+        db = _alert_route_db(rule, creator)
+        db.delete = AsyncMock()
+
+        await delete_alert(rule.id, db, current_user)
+
+        db.delete.assert_awaited_once_with(rule)
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_same_org_owner_can_get_alert_history(self):
+        from api.routes.alert import get_alert_history
+
+        org_id = uuid.uuid4()
+        owner_id = uuid.uuid4()
+        current_user = _alert_route_user(role="user", org_id=org_id, user_id=owner_id)
+        creator = _alert_route_user(role="user", org_id=org_id, user_id=owner_id)
+        rule = _alert_route_rule(created_by=owner_id)
+
+        creator_result = MagicMock()
+        creator_result.scalar_one_or_none.return_value = creator
+        history_result = MagicMock()
+        history_result.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=rule)
+        db.execute = AsyncMock(side_effect=[creator_result, history_result])
+
+        history = await get_alert_history(rule.id, limit=50, offset=0, db=db, current_user=current_user)
+
+        assert history == []
+        assert db.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_same_org_admin_can_rotate_webhook_secret(self):
+        from api.routes.alert import rotate_webhook_secret
+
+        org_id = uuid.uuid4()
+        creator_id = uuid.uuid4()
+        current_user = _alert_route_user(org_id=org_id)
+        creator = _alert_route_user(role="user", org_id=org_id, user_id=creator_id)
+        rule = _alert_route_rule(created_by=creator_id)
+        db = _alert_route_db(rule, creator)
+
+        response = await rotate_webhook_secret(rule.id, db, current_user)
+
+        assert response.webhook_secret_last4 == rule.webhook_secret[-4:]
+        assert rule.webhook_secret != "old-secret-value"
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cross_org_admin_cannot_rotate_webhook_secret(self):
+        from api.routes.alert import rotate_webhook_secret
+
+        current_user = _alert_route_user(org_id=uuid.uuid4())
+        creator = _alert_route_user(role="user", org_id=uuid.uuid4())
+        rule = _alert_route_rule(created_by=creator.id)
+        db = _alert_route_db(rule, creator)
+
+        with pytest.raises(Exception) as exc_info:
+            await rotate_webhook_secret(rule.id, db, current_user)
+
+        assert exc_info.value.status_code == 404
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_same_org_admin_can_reveal_webhook_secret(self):
+        from api.routes.alert import reveal_webhook_secret
+
+        org_id = uuid.uuid4()
+        creator_id = uuid.uuid4()
+        current_user = _alert_route_user(org_id=org_id)
+        creator = _alert_route_user(role="user", org_id=org_id, user_id=creator_id)
+        rule = _alert_route_rule(created_by=creator_id)
+        db = _alert_route_db(rule, creator)
+
+        response = await reveal_webhook_secret(rule.id, db, current_user)
+
+        assert response.webhook_secret == rule.webhook_secret
+
+    @pytest.mark.asyncio
+    async def test_cross_org_admin_cannot_reveal_webhook_secret(self):
+        from api.routes.alert import reveal_webhook_secret
+
+        current_user = _alert_route_user(org_id=uuid.uuid4())
+        creator = _alert_route_user(role="user", org_id=uuid.uuid4())
+        rule = _alert_route_rule(created_by=creator.id)
+        db = _alert_route_db(rule, creator)
+
+        with pytest.raises(Exception) as exc_info:
+            await reveal_webhook_secret(rule.id, db, current_user)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_cross_org_admin_cannot_test_webhook(self):
+        from api.routes.alert import test_webhook
+
+        current_user = _alert_route_user(org_id=uuid.uuid4())
+        creator = _alert_route_user(role="user", org_id=uuid.uuid4())
+        rule = _alert_route_rule(created_by=creator.id)
+        db = _alert_route_db(rule, creator)
+
+        with pytest.raises(Exception) as exc_info:
+            await test_webhook(rule.id, db, current_user)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_local_mode_admin_can_reveal_webhook_secret(self):
+        from api.routes.alert import reveal_webhook_secret
+
+        current_user = _alert_route_user(org_id=None)
+        rule = _alert_route_rule()
+        db = _alert_route_db(rule)
+
+        response = await reveal_webhook_secret(rule.id, db, current_user)
+
+        assert response.webhook_secret == rule.webhook_secret
+        db.execute.assert_not_awaited()
 
 
 class TestAlertHistorySchema:


### PR DESCRIPTION
## Purpose / Description
Alert rules are org-scoped through the user who created them. Some alert endpoints already enforced that org boundary, but webhook secret rotation, webhook secret reveal, and webhook testing loaded alert rules without the same check.

This PR makes alert access control consistent so users from one org cannot manage another org’s alert webhook actions.

## Fixes
Fixes #1286 

## Approach
Centralized alert lookup and org validation in a shared helper for alert routes. The helper returns 404 when an alert does not exist or belongs to another org, matching the existing behavior in other alert endpoints.

Applied that helper to:
- update alert
- delete alert
- alert history
- rotate webhook secret
- reveal webhook secret
- test webhook

Existing role behavior is unchanged. Secret rotation/reveal remain admin-only, and webhook testing remains owner-or-admin.

## How Has This Been Tested?
Ran targeted tests:

```bash
cd observal-server
uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis --with pyarrow pytest ../tests/test_alert_evaluator.py -q
```

Result: `42 passed`

```bash
cd observal-server
uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis --with pyarrow pytest tests/test_multi_tenancy.py::TestAlertOrgIsolation -q
```

Result: `2 passed`

Also ran:

```bash
uv run ruff check observal-server/api/routes/alert.py tests/test_alert_evaluator.py
git diff --check
```

Both passed.

## Learning (optional, can help others)
Found that alert org-scoping was already implemented in update/delete/history routes, but not consistently reused by webhook-related alert actions. This change keeps the existing policy and applies it uniformly.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert access controls to prevent viewing or modifying alerts across organization boundaries.
  * Applied consistent authorization checks to alert updates, deletion, history, webhook testing, and webhook-secret rotation or reveal.
  * Preserved appropriate access for authorized owners, administrators, and local-mode administrators.
* **Tests**
  * Added coverage for alert permissions, missing alerts, webhook actions, history retrieval, and cross-organization access denial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->