### PR TITLE
fix(review): scope registry review queries to the caller's org

### DIFF
--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -52,13 +52,38 @@ VERSION_MODELS = {
 }
 
 
-async def _find_listing(listing_id: str, db: AsyncSession):
+def _owner_org_conditions(model, org_id: uuid.UUID | None) -> list:
+    if org_id is None or not hasattr(model, "owner_org_id"):
+        return []
+    return [model.owner_org_id == org_id]
+
+
+def _apply_owner_org_filter(stmt, model, org_id: uuid.UUID | None):
+    conditions = _owner_org_conditions(model, org_id)
+    return stmt.where(*conditions) if conditions else stmt
+
+
+async def _bundle_belongs_to_org(bundle: ComponentBundle, db: AsyncSession, org_id: uuid.UUID | None) -> bool:
+    if org_id is None:
+        return True
+    submitter = (
+        await db.execute(select(User).where(User.id == bundle.submitted_by, User.org_id == org_id))
+    ).scalar_one_or_none()
+    return submitter is not None
+
+
+async def _find_listing(listing_id: str, db: AsyncSession, org_id: uuid.UUID | None = None):
     """Find a listing by ID, prefix, or name across all component types."""
     optic.trace("listing_id={}", listing_id)
     hits = []
     for listing_type, model in LISTING_MODELS.items():
         try:
-            listing = await resolve_prefix_id(model, listing_id, db)
+            listing = await resolve_prefix_id(
+                model,
+                listing_id,
+                db,
+                extra_conditions=_owner_org_conditions(model, org_id),
+            )
             hits.append((listing_type, listing))
         except HTTPException as e:
             if e.status_code == 400 and "too short" not in str(e.detail):
@@ -76,7 +101,8 @@ async def _find_listing(listing_id: str, db: AsyncSession):
 
     # Fallback: name-based lookup
     for listing_type, model in LISTING_MODELS.items():
-        result = await db.execute(select(model).where(model.name == listing_id))
+        stmt = _apply_owner_org_filter(select(model).where(model.name == listing_id), model, org_id)
+        result = await db.execute(stmt)
         listing = result.scalar_one_or_none()
         if listing:
             return listing_type, listing
@@ -84,7 +110,11 @@ async def _find_listing(listing_id: str, db: AsyncSession):
     return None, None
 
 
-async def _check_agent_components_ready(components, db: AsyncSession) -> tuple[bool, list[dict]]:
+async def _check_agent_components_ready(
+    components,
+    db: AsyncSession,
+    org_id: uuid.UUID | None = None,
+) -> tuple[bool, list[dict]]:
     """Check if all of an agent version's components are approved."""
     optic.trace("components={}", components)
     if not components:
@@ -100,13 +130,23 @@ async def _check_agent_components_ready(components, db: AsyncSession) -> tuple[b
         version_model = VERSION_MODELS.get(comp_type)
         if not model or not version_model:
             continue
-        rows = (
-            await db.execute(
-                select(model.id, model.name, version_model.status)
-                .join(version_model, model.latest_version_id == version_model.id)
-                .where(model.id.in_(ids))
+        stmt = (
+            select(model.id, model.name, version_model.status)
+            .join(version_model, model.latest_version_id == version_model.id)
+            .where(model.id.in_(ids))
+        )
+        stmt = _apply_owner_org_filter(stmt, model, org_id)
+        rows = (await db.execute(stmt)).all()
+        found_ids = {row.id for row in rows}
+        for missing_id in set(ids) - found_ids:
+            blocking.append(
+                {
+                    "component_type": comp_type,
+                    "component_id": str(missing_id),
+                    "name": "",
+                    "status": "not_found_or_not_in_org",
+                }
             )
-        ).all()
         for row in rows:
             if row.status != ListingStatus.approved:
                 blocking.append(
@@ -120,14 +160,19 @@ async def _check_agent_components_ready(components, db: AsyncSession) -> tuple[b
     return len(blocking) == 0, blocking
 
 
-async def _query_pending_agents(db: AsyncSession) -> list[dict]:
+async def _query_pending_agents(db: AsyncSession, org_id: uuid.UUID | None = None) -> list[dict]:
     # Find agents that have ANY pending version (not just latest_version_id).
     # This ensures version updates appear in the review queue after the first
     # version is approved.
     optic.debug("_query_pending_agents called")
     pending_versions_stmt = (
-        select(AgentVersion).where(AgentVersion.status == AgentStatus.pending).order_by(AgentVersion.created_at.desc())
+        select(AgentVersion)
+        .join(Agent, AgentVersion.agent_id == Agent.id)
+        .where(AgentVersion.status == AgentStatus.pending)
+        .order_by(AgentVersion.created_at.desc())
     )
+    if org_id is not None:
+        pending_versions_stmt = pending_versions_stmt.where(Agent.owner_org_id == org_id)
     pending_versions = (await db.execute(pending_versions_stmt)).scalars().all()
 
     if not pending_versions:
@@ -142,7 +187,10 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
 
     # Load the agents
     agent_ids = list(seen_agents.keys())
-    agents_result = await db.execute(select(Agent).where(Agent.id.in_(agent_ids)))
+    agents_stmt = select(Agent).where(Agent.id.in_(agent_ids))
+    if org_id is not None:
+        agents_stmt = agents_stmt.where(Agent.owner_org_id == org_id)
+    agents_result = await db.execute(agents_stmt)
     agents_map = {a.id: a for a in agents_result.scalars().all()}
 
     user_ids = {a.created_by for a in agents_map.values()}
@@ -157,7 +205,7 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
         a = agents_map.get(agent_id)
         if not a:
             continue
-        components_ready, blocking = await _check_agent_components_ready(pending_ver.components, db)
+        components_ready, blocking = await _check_agent_components_ready(pending_ver.components, db, org_id)
         items.append(
             {
                 "type": "agent",
@@ -179,7 +227,11 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
     return items
 
 
-async def _query_pending_components(db: AsyncSession, type_filter: str | None = None) -> list[dict]:
+async def _query_pending_components(
+    db: AsyncSession,
+    type_filter: str | None = None,
+    org_id: uuid.UUID | None = None,
+) -> list[dict]:
     optic.trace("type_filter={}", type_filter)
     models_to_query = (
         {type_filter: LISTING_MODELS[type_filter]} if type_filter and type_filter in LISTING_MODELS else LISTING_MODELS
@@ -192,9 +244,11 @@ async def _query_pending_components(db: AsyncSession, type_filter: str | None = 
         # This ensures version updates appear in the queue after first approval.
         pending_versions_stmt = (
             select(version_model)
+            .join(model, version_model.listing_id == model.id)
             .where(version_model.status == ListingStatus.pending)
             .order_by(version_model.released_at.desc())
         )
+        pending_versions_stmt = _apply_owner_org_filter(pending_versions_stmt, model, org_id)
         pending_versions = (await db.execute(pending_versions_stmt)).scalars().all()
         if not pending_versions:
             continue
@@ -209,7 +263,12 @@ async def _query_pending_components(db: AsyncSession, type_filter: str | None = 
             continue
 
         # Load the listings
-        listings_result = await db.execute(select(model).where(model.id.in_(list(seen_listings.keys()))))
+        listings_stmt = _apply_owner_org_filter(
+            select(model).where(model.id.in_(list(seen_listings.keys()))),
+            model,
+            org_id,
+        )
+        listings_result = await db.execute(listings_stmt)
         listings_map = {r.id: r for r in listings_result.scalars().all()}
 
         for listing_id, pv in seen_listings.items():
@@ -285,16 +344,16 @@ async def list_pending(
 ):
     optic.trace("type={}", type)
     if tab == "agents":
-        result = await _query_pending_agents(db)
+        result = await _query_pending_agents(db, current_user.org_id)
         return result
 
     if tab == "components":
-        result = await _query_pending_components(db, type)
+        result = await _query_pending_components(db, type, current_user.org_id)
         return result
 
     # Default: return both agents and components
-    agents = await _query_pending_agents(db)
-    components = await _query_pending_components(db, type)
+    agents = await _query_pending_agents(db, current_user.org_id)
+    components = await _query_pending_components(db, type, current_user.org_id)
 
     # Merge and sort by created_at (most recent first)
     all_items = agents + components
@@ -449,7 +508,7 @@ async def get_review(
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing_type, listing = await _find_listing(listing_id, db)
+    listing_type, listing = await _find_listing(listing_id, db, current_user.org_id)
 
     if listing:
         result = _serialize_listing_detail(listing_type, listing)
@@ -459,7 +518,10 @@ async def get_review(
             agent_uuid = uuid.UUID(listing_id)
         except ValueError:
             raise HTTPException(status_code=404, detail="Listing not found")
-        agent = (await db.execute(select(Agent).where(Agent.id == agent_uuid))).scalar_one_or_none()
+        agent_stmt = select(Agent).where(Agent.id == agent_uuid)
+        if current_user.org_id is not None:
+            agent_stmt = agent_stmt.where(Agent.owner_org_id == current_user.org_id)
+        agent = (await db.execute(agent_stmt)).scalar_one_or_none()
         if not agent:
             raise HTTPException(status_code=404, detail="Listing not found")
         # Use the pending version for review (not latest_version which is the approved one)
@@ -469,7 +531,7 @@ async def get_review(
         )
         ver = pending_ver or agent.latest_version
         ver_components = ver.components if ver else agent.components
-        components_ready, blocking = await _check_agent_components_ready(ver_components, db)
+        components_ready, blocking = await _check_agent_components_ready(ver_components, db, current_user.org_id)
         result = {
             "type": "agent",
             "id": str(agent.id),
@@ -512,7 +574,12 @@ async def get_review(
             }
             model = LISTING_MODELS.get(c.component_type)
             if model:
-                listing = (await db.execute(select(model).where(model.id == c.component_id))).scalar_one_or_none()
+                stmt = _apply_owner_org_filter(
+                    select(model).where(model.id == c.component_id),
+                    model,
+                    current_user.org_id,
+                )
+                listing = (await db.execute(stmt)).scalar_one_or_none()
                 if listing:
                     comp_data["name"] = listing.name
                     if c.component_type == "prompt":
@@ -542,7 +609,7 @@ async def approve(
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing_type, listing = await _find_listing(listing_id, db)
+    listing_type, listing = await _find_listing(listing_id, db, current_user.org_id)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
@@ -591,7 +658,7 @@ async def reject(
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
     optic.trace("listing_id={}, req={}", listing_id, req)
-    listing_type, listing = await _find_listing(listing_id, db)
+    listing_type, listing = await _find_listing(listing_id, db, current_user.org_id)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
@@ -657,7 +724,10 @@ async def approve_agent(
     optic.trace("agent_id={}, req={}", agent_id, req)
     from services.versioning import parse_semver
 
-    agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
+    agent_stmt = select(Agent).where(Agent.id == agent_id)
+    if current_user.org_id is not None:
+        agent_stmt = agent_stmt.where(Agent.owner_org_id == current_user.org_id)
+    agent = (await db.execute(agent_stmt)).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -681,7 +751,7 @@ async def approve_agent(
             raise HTTPException(status_code=409, detail="Cannot approve: the owner is currently editing this agent")
 
     newest_pending = pending_versions[0]
-    components_ready, blocking = await _check_agent_components_ready(newest_pending.components, db)
+    components_ready, blocking = await _check_agent_components_ready(newest_pending.components, db, current_user.org_id)
     if not components_ready:
         raise HTTPException(
             status_code=422,
@@ -729,7 +799,10 @@ async def reject_agent(
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
     optic.trace("agent_id={}, req={}", agent_id, req)
-    agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
+    agent_stmt = select(Agent).where(Agent.id == agent_id)
+    if current_user.org_id is not None:
+        agent_stmt = agent_stmt.where(Agent.owner_org_id == current_user.org_id)
+    agent = (await db.execute(agent_stmt)).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -781,10 +854,13 @@ async def approve_bundle(
     bundle = (await db.execute(select(ComponentBundle).where(ComponentBundle.id == bundle_id))).scalar_one_or_none()
     if not bundle:
         raise HTTPException(status_code=404, detail="Bundle not found")
+    if not await _bundle_belongs_to_org(bundle, db, current_user.org_id):
+        raise HTTPException(status_code=404, detail="Bundle not found")
 
     count = 0
     for model in LISTING_MODELS.values():
-        result = await db.execute(select(model).where(model.bundle_id == bundle_id))
+        stmt = _apply_owner_org_filter(select(model).where(model.bundle_id == bundle_id), model, current_user.org_id)
+        result = await db.execute(stmt)
         for listing in result.scalars().all():
             if listing.latest_version and is_actively_editing(listing.latest_version):
                 raise HTTPException(
@@ -810,10 +886,13 @@ async def reject_bundle(
     bundle = (await db.execute(select(ComponentBundle).where(ComponentBundle.id == bundle_id))).scalar_one_or_none()
     if not bundle:
         raise HTTPException(status_code=404, detail="Bundle not found")
+    if not await _bundle_belongs_to_org(bundle, db, current_user.org_id):
+        raise HTTPException(status_code=404, detail="Bundle not found")
 
     count = 0
     for model in LISTING_MODELS.values():
-        result = await db.execute(select(model).where(model.bundle_id == bundle_id))
+        stmt = _apply_owner_org_filter(select(model).where(model.bundle_id == bundle_id), model, current_user.org_id)
+        result = await db.execute(stmt)
         for listing in result.scalars().all():
             if listing.latest_version and is_actively_editing(listing.latest_version):
                 raise HTTPException(
@@ -840,7 +919,7 @@ async def get_related_skills(
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing_type, listing = await _find_listing(listing_id, db)
+    listing_type, listing = await _find_listing(listing_id, db, current_user.org_id)
     if not listing or listing_type != "mcp":
         return {"skills": []}
 
@@ -860,6 +939,7 @@ async def get_related_skills(
         )
         .order_by(SkillListing.created_at.desc())
     )
+    stmt = _apply_owner_org_filter(stmt, SkillListing, current_user.org_id)
     skills = (await db.execute(stmt)).scalars().all()
 
     user_ids = {s.submitted_by for s in skills}
@@ -902,7 +982,7 @@ async def approve_mcp_with_skills(
     current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
     optic.trace("listing_id={}, req={}", listing_id, req)
-    listing_type, listing = await _find_listing(listing_id, db)
+    listing_type, listing = await _find_listing(listing_id, db, current_user.org_id)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing_type != "mcp":
@@ -917,7 +997,12 @@ async def approve_mcp_with_skills(
             skill_uuid = uuid.UUID(sid)
         except ValueError:
             continue
-        skill = (await db.execute(select(SkillListing).where(SkillListing.id == skill_uuid))).scalar_one_or_none()
+        stmt = _apply_owner_org_filter(
+            select(SkillListing).where(SkillListing.id == skill_uuid),
+            SkillListing,
+            current_user.org_id,
+        )
+        skill = (await db.execute(stmt)).scalar_one_or_none()
         if skill and skill.status == ListingStatus.pending:
             skill.status = ListingStatus.approved
             skill.rejection_reason = None

--- a/tests/test_tenant_scope_review.py
+++ b/tests/test_tenant_scope_review.py
@@ -1,0 +1,378 @@
+# SPDX-FileCopyrightText: 2026 Nav-Prak <naveenprakaasam@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tenant-scoping regression coverage for the registry review routes.
+
+These tests assert that review queries are constrained to the caller's
+organization (``owner_org_id``) so a reviewer in one org cannot read or act on
+listings, agent components, or bundles owned by another org.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from api.routes import review
+from api.routes.review import _apply_owner_org_filter, _owner_org_conditions
+from models.mcp import ListingStatus, McpListing
+from models.user import UserRole
+
+
+def _scalar_result(obj=None):
+    result = MagicMock()
+    result.scalar_one.return_value = obj
+    result.scalar_one_or_none.return_value = obj
+    result.scalars.return_value.all.return_value = [obj] if obj is not None else []
+    result.all.return_value = []
+    return result
+
+
+def _where(stmt):
+    """WHERE-clause text of a statement.
+
+    A full-entity ``select(Model)`` always lists ``owner_org_id`` in its SELECT
+    columns, so the org predicate must be checked against the WHERE clause only.
+    """
+    return str(stmt.whereclause) if stmt.whereclause is not None else ""
+
+
+def _reviewer(org_id):
+    """A reviewer in org ``org_id`` (or org-less super-admin when None)."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "reviewer@example.com"
+    user.role = UserRole.reviewer
+    user.org_id = org_id
+    return user
+
+
+class _RecordingSession:
+    """Async DB stub that records executed statements and returns queued results.
+
+    Lets route-level tests assert the org predicate reached the query without a
+    live database.  Unqueued executes default to an empty result.
+    """
+
+    def __init__(self, results=None):
+        self.statements = []
+        self._results = list(results or [])
+        self.committed = False
+
+    async def execute(self, stmt, *args, **kwargs):
+        self.statements.append(stmt)
+        if self._results:
+            return self._results.pop(0)
+        return _scalar_result(None)
+
+    async def commit(self):
+        self.committed = True
+
+    async def flush(self):
+        pass
+
+    async def refresh(self, obj):
+        pass
+
+
+def test_review_owner_org_filter_adds_tenant_condition():
+    org_id = uuid.uuid4()
+    stmt = _apply_owner_org_filter(select(McpListing), McpListing, org_id)
+
+    # No org -> no extra conditions; with an org -> an owner_org_id predicate.
+    assert _owner_org_conditions(McpListing, None) == []
+    assert "owner_org_id" in str(stmt)
+
+
+@pytest.mark.asyncio
+async def test_find_listing_passes_org_conditions_to_prefix_and_name_lookup():
+    from api.routes.review import _find_listing
+
+    org_id = uuid.uuid4()
+    listing = MagicMock()
+    listing.id = uuid.uuid4()
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(listing))
+    seen_conditions = []
+
+    async def fake_resolve(*args, **kwargs):
+        seen_conditions.append(kwargs.get("extra_conditions"))
+        raise HTTPException(status_code=404, detail="not found")
+
+    with patch("api.routes.review.resolve_prefix_id", AsyncMock(side_effect=fake_resolve)):
+        listing_type, found = await _find_listing("tenant-mcp", db, org_id)
+
+    assert listing_type == "mcp"
+    assert found is listing
+    # Org conditions are forwarded to the prefix lookup and the name fallback.
+    assert any(seen_conditions)
+    assert "owner_org_id" in str(db.execute.call_args[0][0])
+
+
+@pytest.mark.asyncio
+async def test_check_agent_components_ready_blocks_components_outside_org():
+    from api.routes.review import _check_agent_components_ready
+
+    comp = MagicMock()
+    comp.component_type = "mcp"
+    comp.component_id = uuid.uuid4()
+
+    empty_rows = MagicMock()
+    empty_rows.all.return_value = []
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=empty_rows)
+
+    ready, blocking = await _check_agent_components_ready([comp], db, uuid.uuid4())
+
+    # A component the reviewer's org cannot see blocks approval rather than
+    # silently passing.
+    assert ready is False
+    assert blocking == [
+        {
+            "component_type": "mcp",
+            "component_id": str(comp.component_id),
+            "name": "",
+            "status": "not_found_or_not_in_org",
+        }
+    ]
+    assert "owner_org_id" in str(db.execute.call_args[0][0])
+
+
+@pytest.mark.asyncio
+async def test_bundle_belongs_to_org_requires_submitter_membership():
+    from api.routes.review import _bundle_belongs_to_org
+
+    bundle = MagicMock()
+    bundle.submitted_by = uuid.uuid4()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(None))
+
+    # No org context -> always allowed; with an org -> submitter must be a member.
+    assert await _bundle_belongs_to_org(bundle, db, None) is True
+    assert await _bundle_belongs_to_org(bundle, db, uuid.uuid4()) is False
+    assert "org_id" in str(db.execute.call_args[0][0])
+
+
+# ---------------------------------------------------------------------------
+# Route-level scoping: each handler must constrain reads/writes to the caller's
+# org so a reviewer cannot list, read, or act on another org's records.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tab", [None, "agents", "components"])
+async def test_list_pending_threads_caller_org_to_queries(tab):
+    org_id = uuid.uuid4()
+    agents = AsyncMock(return_value=[])
+    components = AsyncMock(return_value=[])
+    db = _RecordingSession()
+
+    with (
+        patch.object(review, "_query_pending_agents", agents),
+        patch.object(review, "_query_pending_components", components),
+    ):
+        await review.list_pending(type=None, tab=tab, db=db, current_user=_reviewer(org_id))
+
+    # Whichever helper(s) the tab dispatches to must receive the caller's org.
+    if tab != "components":
+        assert agents.await_args.args[1] == org_id
+    if tab != "agents":
+        assert components.await_args.args[2] == org_id
+
+
+@pytest.mark.asyncio
+async def test_get_review_denies_cross_org_agent():
+    org_id = uuid.uuid4()
+    db = _RecordingSession(results=[_scalar_result(None)])  # agent fallback finds nothing
+
+    with (
+        patch.object(review, "_find_listing", AsyncMock(return_value=(None, None))) as find,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await review.get_review(listing_id=str(uuid.uuid4()), db=db, current_user=_reviewer(org_id))
+
+    assert exc.value.status_code == 404
+    assert find.await_args.args[2] == org_id
+    assert any("owner_org_id" in _where(s) for s in db.statements)
+
+
+@pytest.mark.asyncio
+async def test_approve_denies_cross_org_listing():
+    org_id = uuid.uuid4()
+    db = _RecordingSession()
+
+    with (
+        patch.object(review, "_find_listing", AsyncMock(return_value=(None, None))) as find,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await review.approve(listing_id="other-org-mcp", db=db, current_user=_reviewer(org_id))
+
+    assert exc.value.status_code == 404
+    assert find.await_args.args[2] == org_id
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_reject_denies_cross_org_listing():
+    org_id = uuid.uuid4()
+    db = _RecordingSession()
+
+    with (
+        patch.object(review, "_find_listing", AsyncMock(return_value=(None, None))) as find,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await review.reject(
+            listing_id="other-org-mcp",
+            req=MagicMock(reason="nope"),
+            db=db,
+            current_user=_reviewer(org_id),
+        )
+
+    assert exc.value.status_code == 404
+    assert find.await_args.args[2] == org_id
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_approve_agent_denies_cross_org_agent():
+    org_id = uuid.uuid4()
+    db = _RecordingSession(results=[_scalar_result(None)])
+
+    with pytest.raises(HTTPException) as exc:
+        await review.approve_agent(agent_id=uuid.uuid4(), req=None, db=db, current_user=_reviewer(org_id))
+
+    assert exc.value.status_code == 404
+    assert "owner_org_id" in _where(db.statements[0])
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_approve_agent_query_is_unscoped_for_super_admin():
+    # A super-admin has no org and must be able to reach any agent (no filter).
+    db = _RecordingSession(results=[_scalar_result(None)])
+
+    with pytest.raises(HTTPException) as exc:
+        await review.approve_agent(agent_id=uuid.uuid4(), req=None, db=db, current_user=_reviewer(None))
+
+    assert exc.value.status_code == 404
+    assert "owner_org_id" not in _where(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_reject_agent_denies_cross_org_agent():
+    org_id = uuid.uuid4()
+    db = _RecordingSession(results=[_scalar_result(None)])
+
+    with pytest.raises(HTTPException) as exc:
+        await review.reject_agent(
+            agent_id=uuid.uuid4(),
+            req=MagicMock(reason="nope"),
+            db=db,
+            current_user=_reviewer(org_id),
+        )
+
+    assert exc.value.status_code == 404
+    assert "owner_org_id" in _where(db.statements[0])
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_approve_bundle_denies_cross_org_bundle():
+    org_id = uuid.uuid4()
+    bundle = MagicMock()
+    bundle.submitted_by = uuid.uuid4()
+    db = _RecordingSession(results=[_scalar_result(bundle)])  # bundle row found...
+    belongs = AsyncMock(return_value=False)  # ...but submitter is in another org
+
+    with (
+        patch.object(review, "_bundle_belongs_to_org", belongs),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await review.approve_bundle(bundle_id=uuid.uuid4(), db=db, current_user=_reviewer(org_id))
+
+    assert exc.value.status_code == 404
+    assert belongs.await_args.args[2] == org_id
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_reject_bundle_denies_cross_org_bundle():
+    org_id = uuid.uuid4()
+    bundle = MagicMock()
+    bundle.submitted_by = uuid.uuid4()
+    db = _RecordingSession(results=[_scalar_result(bundle)])
+    belongs = AsyncMock(return_value=False)
+
+    with (
+        patch.object(review, "_bundle_belongs_to_org", belongs),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await review.reject_bundle(
+            bundle_id=uuid.uuid4(),
+            req=MagicMock(reason="nope"),
+            db=db,
+            current_user=_reviewer(org_id),
+        )
+
+    assert exc.value.status_code == 404
+    assert belongs.await_args.args[2] == org_id
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_get_related_skills_returns_empty_for_cross_org_mcp():
+    org_id = uuid.uuid4()
+    db = _RecordingSession()
+
+    with patch.object(review, "_find_listing", AsyncMock(return_value=(None, None))) as find:
+        result = await review.get_related_skills(listing_id="other-org-mcp", db=db, current_user=_reviewer(org_id))
+
+    assert result == {"skills": []}
+    assert find.await_args.args[2] == org_id
+
+
+@pytest.mark.asyncio
+async def test_approve_with_skills_denies_cross_org_mcp():
+    org_id = uuid.uuid4()
+    db = _RecordingSession()
+
+    with (
+        patch.object(review, "_find_listing", AsyncMock(return_value=(None, None))) as find,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await review.approve_mcp_with_skills(
+            listing_id="other-org-mcp",
+            req=review.McpBulkApproveRequest(skill_ids=[]),
+            db=db,
+            current_user=_reviewer(org_id),
+        )
+
+    assert exc.value.status_code == 404
+    assert find.await_args.args[2] == org_id
+    assert db.committed is False
+
+
+@pytest.mark.asyncio
+async def test_approve_with_skills_scopes_skill_lookup_and_skips_cross_org_skill():
+    org_id = uuid.uuid4()
+    listing = MagicMock()
+    listing.id = uuid.uuid4()
+    listing.name = "srv"
+    listing.status = ListingStatus.approved
+    db = _RecordingSession(results=[_scalar_result(None)])  # the requested skill is in another org
+
+    with patch.object(review, "_find_listing", AsyncMock(return_value=("mcp", listing))):
+        result = await review.approve_mcp_with_skills(
+            listing_id="srv",
+            req=review.McpBulkApproveRequest(skill_ids=[str(uuid.uuid4())]),
+            db=db,
+            current_user=_reviewer(org_id),
+        )
+
+    # The cross-org skill is not found under the org filter, so nothing is approved.
+    assert result["approved_skills"] == 0
+    assert result["skill_ids"] == []
+    assert any("owner_org_id" in _where(s) for s in db.statements)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description

Constrain registry review access to the reviewer's organization so a reviewer in one org cannot list, read, approve, reject, or bulk-act on another org's submissions.

This is part of the AUDIT2 tenant-scoping work and is split out from the closed broader tenant-scope PR #1184 to keep the change smaller and independently reviewable.

## Fixes

* Refs #1184
* Addresses AUDIT2 tenant-scoping for registry review paths

## Approach

This change scopes review-queue listing, agent, component, and bundle lookups to the caller's `owner_org_id`.

- Adds `_owner_org_conditions` and `_apply_owner_org_filter` helpers.
- Threads `org_id` through `_find_listing`, `_check_agent_components_ready`, `_query_pending_agents`, `_query_pending_components`, and review mutation handlers.
- Applies org scoping to list/detail/approve/reject, agent approve/reject, bundle approve/reject, related-skills, and approve-with-skills paths.
- Treats components the caller's org cannot see as blocking rather than silently approvable.
- Preserves the existing org-less/super-admin behavior by omitting the org predicate when the caller has no org.

## How Has This Been Tested?

Tested the new review tenant-scope coverage and linted/formatted the changed files.

Targeted tests:

```bash
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml \
  --with typer --with rich --with hypothesis --with pyarrow \
  pytest ../tests/test_tenant_scope_review.py -q
```

Result: 18 review tenant-scope tests passed.

Lint/format:

```bash
uv run --with ruff==0.15.10 ruff check observal-server/api/routes/review.py ../tests/test_tenant_scope_review.py
uv run --with ruff==0.15.10 ruff format --check observal-server/api/routes/review.py ../tests/test_tenant_scope_review.py
```

Also re-ran adjacent review/agent/bundle/draft suites as part of the split verification; no regressions were found.


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review listings and actions now remain isolated to the reviewer’s organization.
  * Cross-organization components, bundles, skills, approvals, and rejections are blocked.
  * Unauthorized review actions no longer commit changes.
  * Organization-less super-admin access remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->