### PR TITLE
fix(security-events): scope events by org

### DIFF
--- a/observal-server/api/routes/admin/org.py
+++ b/observal-server/api/routes/admin/org.py
@@ -28,7 +28,6 @@ async def get_security_events(
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Query the security events audit log from ClickHouse."""
-    del current_user
     optic.debug(
         "org.get_security_events: event_type={}, severity={}, actor_email={}", event_type, severity, actor_email
     )
@@ -56,6 +55,9 @@ async def get_security_events(
         else:
             conditions.append("actor_email = {ae:String}")
             params["param_ae"] = actor_email
+    if current_user.org_id is not None:
+        conditions.append("org_id = {org_id:String}")
+        params["param_org_id"] = str(current_user.org_id)
 
     where = " AND ".join(conditions)
     limit = min(max(int(limit), 1), 1000)

--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -384,12 +384,17 @@ async def login(request: Request, req: LoginRequest, db: AsyncSession = Depends(
     result = await db.execute(stmt)
     user = result.scalar_one_or_none()
     if not user or not user.verify_password(req.password):
+        # Attribute a wrong-password failure for an existing user to that user so
+        # the event resolves to their org and stays visible to tenant admins;
+        # unknown-identifier attempts have no org and remain global.
         await emit_security_event(
             SecurityEvent(
                 event_type=EventType.LOGIN_FAILURE,
                 severity=Severity.WARNING,
                 outcome="failure",
-                actor_email=identifier,
+                actor_id=str(user.id) if user else "",
+                actor_email=user.email if user else identifier,
+                actor_role=user.role.value if user else "",
                 source_ip=source_ip,
                 user_agent=user_agent,
                 detail="Invalid credentials",
@@ -1656,12 +1661,17 @@ async def issue_token(request: Request, req: TokenRequest, db: AsyncSession = De
     result = await db.execute(stmt)
     user = result.scalar_one_or_none()
     if not user or not user.verify_password(req.password):
+        # Attribute a wrong-password failure for an existing user to that user so
+        # the event resolves to their org and stays visible to tenant admins;
+        # unknown-identifier attempts have no org and remain global.
         await emit_security_event(
             SecurityEvent(
                 event_type=EventType.LOGIN_FAILURE,
                 severity=Severity.WARNING,
                 outcome="failure",
-                actor_email=identifier,
+                actor_id=str(user.id) if user else "",
+                actor_email=user.email if user else identifier,
+                actor_role=user.role.value if user else "",
                 source_ip=source_ip,
                 user_agent=user_agent,
                 detail="Invalid credentials (token endpoint)",

--- a/observal-server/clickhouse/migrations/004_security_events_org_scope.sql
+++ b/observal-server/clickhouse/migrations/004_security_events_org_scope.sql
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE security_events ADD COLUMN IF NOT EXISTS org_id String DEFAULT '';
+ALTER TABLE security_events ADD INDEX IF NOT EXISTS idx_security_events_org_id org_id TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/observal-server/services/security_events.py
+++ b/observal-server/services/security_events.py
@@ -25,6 +25,10 @@ from loguru import logger as optic
 
 logger = logging.getLogger("observal.security")
 
+# Cache of actor_id -> org_id so repeated events from the same actor do not
+# re-query the database on every emit.
+_ACTOR_ORG_CACHE: dict[str, str] = {}
+
 
 class Severity(str, Enum):
     INFO = "info"
@@ -118,6 +122,10 @@ class SecurityEvent:
 async def emit_security_event(event: SecurityEvent) -> None:
     """Emit a security event to structured logging and ClickHouse."""
     optic.trace("emitting security event: {} ({})", event.event_type, event.severity)
+    # Client callers never set org_id; resolve it from the actor so the event can
+    # be scoped to a tenant before it is logged or persisted.
+    if not event.org_id:
+        event.org_id = await _resolve_actor_org_id(event.actor_id)
     log_data = event.to_log_dict()
 
     log_level = {
@@ -140,6 +148,33 @@ async def emit_security_event(event: SecurityEvent) -> None:
         await _query("INSERT INTO security_events FORMAT JSONEachRow", data=data)
     except Exception:
         logger.debug("ClickHouse security_events insert skipped", exc_info=True)
+
+
+async def _resolve_actor_org_id(actor_id: str) -> str:
+    """Resolve an actor's org id from the database, caching the result per actor."""
+    if not actor_id:
+        return ""
+    if actor_id in _ACTOR_ORG_CACHE:
+        return _ACTOR_ORG_CACHE[actor_id]
+    try:
+        actor_uuid = uuid.UUID(actor_id)
+    except ValueError:
+        return ""
+    try:
+        from sqlalchemy import select
+
+        from database import async_session
+        from models.user import User
+
+        async with async_session() as db:
+            result = await db.execute(select(User.org_id).where(User.id == actor_uuid))
+            org_id = result.scalar_one_or_none()
+    except Exception:
+        logger.debug("Security event actor org lookup skipped", exc_info=True)
+        return ""
+    resolved = str(org_id) if org_id else ""
+    _ACTOR_ORG_CACHE[actor_id] = resolved
+    return resolved
 
 
 def _extract_request_info(request: Any) -> tuple[str, str]:

--- a/tests/test_tenant_scope_security_events.py
+++ b/tests/test_tenant_scope_security_events.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2026 Nav-Prak <naveenprakaasam@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tenant-scoping regression coverage for security events.
+
+Security events are stamped with the actor's organization on emit and the
+admin query is constrained to the caller's org, so a tenant admin cannot read
+another organization's security events.
+"""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.user import UserRole
+
+
+def _admin_user(org_id: uuid.UUID | None = None):
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "admin@example.com"
+    user.role = UserRole.admin
+    user.org_id = org_id
+    return user
+
+
+@pytest.mark.asyncio
+async def test_security_events_query_is_org_scoped_for_tenant_admin():
+    from api.routes.admin.org import get_security_events
+
+    org_id = uuid.uuid4()
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.json.return_value = {"data": [], "rows": 0}
+    mock_query = AsyncMock(return_value=fake_resp)
+
+    with patch("services.clickhouse._query", mock_query):
+        result = await get_security_events(current_user=_admin_user(org_id))
+
+    assert result == {"events": [], "total": 0}
+    sql_arg = mock_query.call_args[0][0]
+    params_arg = mock_query.call_args[0][1]
+    assert "org_id = {org_id:String}" in sql_arg
+    assert params_arg["param_org_id"] == str(org_id)
+
+
+@pytest.mark.asyncio
+async def test_emit_security_event_resolves_org_id_before_clickhouse_insert():
+    from services.security_events import EventType, SecurityEvent, Severity, emit_security_event
+
+    event = SecurityEvent(
+        event_type=EventType.PERMISSION_DENIED,
+        severity=Severity.WARNING,
+        outcome="failure",
+        actor_id=str(uuid.uuid4()),
+    )
+    mock_query = AsyncMock()
+
+    with (
+        patch("services.security_events._resolve_actor_org_id", AsyncMock(return_value="org-a")),
+        patch("services.clickhouse._query", mock_query),
+    ):
+        await emit_security_event(event)
+
+    assert event.org_id == "org-a"
+    inserted = json.loads(mock_query.call_args.kwargs["data"])
+    assert inserted["org_id"] == "org-a"
+
+
+def test_security_events_org_id_has_existing_deployment_migration():
+    """org_id must be backfilled via ALTER, not only the CREATE TABLE.
+
+    CREATE TABLE IF NOT EXISTS is a no-op once the table exists, so a
+    deployment that created security_events before org_id was added would
+    never gain the column and would fail on org-scoped insert/query.
+    """
+    from services.clickhouse.schema import INIT_SQL
+
+    sql_blob = "\n".join(INIT_SQL)
+    assert "ALTER TABLE security_events ADD COLUMN IF NOT EXISTS org_id" in sql_blob
+    assert "ALTER TABLE security_events ADD INDEX IF NOT EXISTS idx_org_id" in sql_blob
+
+
+@pytest.mark.asyncio
+async def test_resolve_actor_org_id_reads_database_once_and_caches_result():
+    import services.security_events as security_events
+
+    security_events._ACTOR_ORG_CACHE.clear()
+    actor_id = str(uuid.uuid4())
+    org_id = uuid.uuid4()
+
+    query_result = MagicMock()
+    query_result.scalar_one_or_none.return_value = org_id
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=query_result)
+
+    class FakeSession:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("database.async_session", MagicMock(return_value=FakeSession())):
+        first = await security_events._resolve_actor_org_id(actor_id)
+        second = await security_events._resolve_actor_org_id(actor_id)
+
+    assert first == str(org_id)
+    assert second == str(org_id)
+    db.execute.assert_awaited_once()

--- a/tests/test_tenant_scope_security_events.py
+++ b/tests/test_tenant_scope_security_events.py
@@ -13,6 +13,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from models.user import UserRole
 
@@ -110,3 +111,81 @@ async def test_resolve_actor_org_id_reads_database_once_and_caches_result():
     assert first == str(org_id)
     assert second == str(org_id)
     db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Login-failure attribution: a wrong-password attempt against a *real* user must
+# carry that user's id so emit_security_event can resolve their org -- otherwise
+# the org-scoped admin query hides the failure from the user's tenant admins.
+# ---------------------------------------------------------------------------
+
+
+def _failed_login_event(handler_name, *, user, identifier):
+    """Drive the auth handler's wrong-password path and return the emitted event.
+
+    Calls the undecorated handler (``__wrapped__``) to bypass the rate limiter.
+    """
+    from api.routes import auth
+
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = user
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+
+    req = MagicMock()
+    req.email = identifier
+    req.password = "wrong-password"
+
+    captured = []
+    emit = AsyncMock(side_effect=lambda ev: captured.append(ev))
+    raw = getattr(auth, handler_name).__wrapped__
+
+    async def _run():
+        with (
+            patch("api.routes.auth.emit_security_event", emit),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await raw(request=MagicMock(), req=req, db=db)
+        assert exc.value.status_code == 401
+
+    return _run, captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handler_name", ["login", "issue_token"])
+async def test_login_failure_for_existing_user_is_org_attributable(handler_name):
+    from services.security_events import EventType
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "real@tenant.example"
+    user.role = UserRole.user
+    user.verify_password = MagicMock(return_value=False)
+
+    run, captured = _failed_login_event(handler_name, user=user, identifier=user.email)
+    await run()
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.event_type == EventType.LOGIN_FAILURE
+    # Attributed to the real user so emit resolves their org (visible to tenant admins).
+    assert event.actor_id == str(user.id)
+    assert event.actor_email == user.email
+    assert event.actor_role == user.role.value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handler_name", ["login", "issue_token"])
+async def test_login_failure_for_unknown_user_stays_orgless(handler_name):
+    from services.security_events import EventType
+
+    identifier = "ghost@nowhere.example"
+    run, captured = _failed_login_event(handler_name, user=None, identifier=identifier)
+    await run()
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.event_type == EventType.LOGIN_FAILURE
+    # No such user -> no org attribution; the attempt stays global.
+    assert event.actor_id == ""
+    assert event.actor_email == identifier

--- a/tests/test_tenant_scope_security_events.py
+++ b/tests/test_tenant_scope_security_events.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Nav-Prak <naveenprakaasam@gmail.com>
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 """Tenant-scoping regression coverage for security events.
 
@@ -77,11 +77,11 @@ def test_security_events_org_id_has_existing_deployment_migration():
     deployment that created security_events before org_id was added would
     never gain the column and would fail on org-scoped insert/query.
     """
-    from services.clickhouse.schema import INIT_SQL
+    from services.clickhouse.migrations import MIGRATIONS_DIR
 
-    sql_blob = "\n".join(INIT_SQL)
-    assert "ALTER TABLE security_events ADD COLUMN IF NOT EXISTS org_id" in sql_blob
-    assert "ALTER TABLE security_events ADD INDEX IF NOT EXISTS idx_org_id" in sql_blob
+    sql = (MIGRATIONS_DIR / "004_security_events_org_scope.sql").read_text()
+    assert "ALTER TABLE security_events ADD COLUMN IF NOT EXISTS org_id" in sql
+    assert "ALTER TABLE security_events ADD INDEX IF NOT EXISTS idx_security_events_org_id" in sql
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description

Scope security-event reads to the caller's organization so a tenant admin cannot list another organization's security events.

This is part of the AUDIT2 tenant-scoping work and is split out from the closed broader tenant-scope PR #1184 to keep the security-events change independently reviewable.

## Fixes

* Refs #1184
* Addresses AUDIT2 tenant-scoping for security-events admin paths

## Approach

This change stamps security events with an `org_id` and filters the admin security-events query by the current admin's org.

- Resolves the actor's organization when emitting security events.
- Adds org filtering to the admin `get_security_events` query.
- Adds an existing-deployment ClickHouse migration for `security_events.org_id` and its bloom-filter index.
- Preserves org-less/global behavior when an event cannot be attributed to a known user.
- Attributes wrong-password failures for existing users to that user so tenant admins can see failed login attempts for their own users.
- Keeps unknown-identifier login failures orgless/global.

## How Has This Been Tested?

Targeted security-events tenant-scope tests:

```bash
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml \
  --with typer --with rich --with hypothesis --with pyarrow \
  pytest ../tests/test_tenant_scope_security_events.py -q
```

Result: security-events tenant-scope tests passed, including schema migration coverage and login-failure attribution for both `/login` and `/token`.

Lint/format:

```bash
uv run --with ruff==0.15.10 ruff check \
  observal-server/services/security_events.py \
  observal-server/api/routes/admin/org.py \
  observal-server/api/routes/auth.py \
  observal-server/services/clickhouse/schema.py \
  tests/test_tenant_scope_security_events.py

uv run --with ruff==0.15.10 ruff format --check \
  observal-server/services/security_events.py \
  observal-server/api/routes/admin/org.py \
  observal-server/api/routes/auth.py \
  observal-server/services/clickhouse/schema.py \
  tests/test_tenant_scope_security_events.py
```

Also re-ran adjacent auth/security and security-events suites as part of split verification; no regressions were found.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->
