### PR TITLE
test: add sandbox CLI command tests

### DIFF
--- a/tests/test_cmd_sandbox.py
+++ b/tests/test_cmd_sandbox.py
@@ -1,0 +1,886 @@
+# SPDX-FileCopyrightText: 2026 Abdul Moiz Hussain <abdulmoizx97@gmail.com>
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral coverage for the sandbox registry CLI."""
+
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext
+from unittest.mock import MagicMock, call, mock_open
+
+import pytest
+from typer.testing import CliRunner
+
+from observal_cli import client, cmd_sandbox, config
+from observal_cli.constants import VALID_SANDBOX_RUNTIME_TYPES
+from observal_cli.main import app
+
+runner = CliRunner()
+COMMAND = ("registry", "sandbox")
+VALID_SUBMIT = (
+    "--name",
+    "runner",
+    "--description",
+    "Run tests",
+    "--runtime-type",
+    "docker",
+    "--image",
+    "python:3.12",
+)
+
+EXAMPLES = {
+    "python-pytest": {
+        "name": "python-pytest",
+        "version": "1.0.0",
+        "description": "Run Python tests in a reviewed Docker image",
+        "owner": "your-team",
+        "runtime_type": "docker",
+        "image": "python:3.12-slim",
+        "resource_limits": {"timeout": 60, "memory_mb": 512, "cpu_count": 1},
+        "network_policy": "none",
+        "entrypoint": "pytest",
+        "runtime_config": {},
+        "source_url": "https://github.com/docker-library/python",
+        "source_ref": "master",
+        "sandbox_path": "3.12/slim-bookworm",
+    },
+    "node-tests": {
+        "name": "node-tests",
+        "version": "1.0.0",
+        "description": "Run Node test and build commands",
+        "owner": "your-team",
+        "runtime_type": "docker",
+        "image": "node:22-alpine",
+        "resource_limits": {"timeout": 120, "memory_mb": 1024, "cpu_count": 2},
+        "network_policy": "none",
+        "entrypoint": "npm test",
+        "runtime_config": {},
+        "source_url": "https://github.com/nodejs/docker-node",
+        "source_ref": "main",
+        "sandbox_path": "22/alpine3.22",
+    },
+    "go-tests": {
+        "name": "go-tests",
+        "version": "1.0.0",
+        "description": "Run Go tests in an Alpine Go image",
+        "owner": "your-team",
+        "runtime_type": "docker",
+        "image": "golang:1.24-alpine",
+        "resource_limits": {"timeout": 180, "memory_mb": 1024, "cpu_count": 2},
+        "network_policy": "none",
+        "entrypoint": "go test ./...",
+        "runtime_config": {},
+        "source_url": "https://github.com/docker-library/golang",
+        "source_ref": "master",
+        "sandbox_path": "1.24/alpine3.21",
+    },
+}
+
+
+def invoke(*args: str):
+    return runner.invoke(app, [*COMMAND, *args])
+
+
+@pytest.fixture(autouse=True)
+def _boundaries(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    """Keep each command at its network, config, prompt, and render boundaries."""
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("unexpected external boundary call")
+
+    config_load = MagicMock(return_value={"username": "alice"})
+    monkeypatch.setenv("OBSERVAL_NO_UPDATE_CHECK", "1")
+    monkeypatch.setattr("observal_cli.main._migrate_legacy_mcp_configs", lambda: None)
+    monkeypatch.setattr("observal_cli.main._try_lockfile_migration", lambda: None)
+    monkeypatch.setattr("observal_cli.optic.setup_optic", lambda **_kwargs: None)
+    monkeypatch.setattr(cmd_sandbox, "spinner", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(cmd_sandbox.config, "load", config_load)
+    monkeypatch.setattr(cmd_sandbox.config, "save_last_results", unexpected)
+    monkeypatch.setattr(cmd_sandbox, "text_input", unexpected)
+    monkeypatch.setattr(cmd_sandbox, "select_one", unexpected)
+    monkeypatch.setattr(cmd_sandbox, "output_json", unexpected)
+    monkeypatch.setattr(cmd_sandbox.console, "print", unexpected)
+    for method in ("get", "post", "put", "patch", "delete"):
+        monkeypatch.setattr(client, method, unexpected)
+    monkeypatch.setattr(client, "resolve_registry_reference", unexpected)
+    monkeypatch.setattr(client, "resolve_team_id", unexpected)
+    return {"config_load": config_load}
+
+
+def test_register_sandbox_mounts_the_command_group() -> None:
+    parent = MagicMock()
+
+    cmd_sandbox.register_sandbox(parent)
+
+    parent.add_typer.assert_called_once_with(cmd_sandbox.sandbox_app, name="sandbox")
+
+
+def test_submit_example_renders_exact_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    output_json = MagicMock()
+    monkeypatch.setattr(cmd_sandbox, "output_json", output_json)
+
+    result = invoke("submit", "--example")
+
+    assert result.exit_code == 0, result.output
+    assert result.output == ""
+    output_json.assert_called_once_with(EXAMPLES)
+
+
+def test_submit_rejects_conflicting_draft_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve = MagicMock()
+    post = MagicMock()
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", "--draft", "--submit", "@draft")
+
+    assert result.exit_code == 1
+    assert "Cannot use --draft and --submit together" in result.output
+    resolve.assert_not_called()
+    post.assert_not_called()
+
+
+def test_submit_existing_draft_resolves_registry_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    post = MagicMock(return_value={"id": "sandbox-id"})
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", "--submit", "platform/python-runner")
+
+    assert result.exit_code == 0, result.output
+    assert "Draft submitted for review!" in result.output
+    assert "sandbox-id" in result.output
+    resolve.assert_called_once_with("sandbox", "platform/python-runner")
+    post.assert_called_once_with("/api/v1/sandboxes/sandbox-id/submit")
+
+
+@pytest.mark.parametrize(("owner", "expected_owner"), [(None, "alice"), ("publisher", "publisher")])
+def test_submit_from_file_posts_exact_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    _boundaries: dict[str, MagicMock],
+    owner: str | None,
+    expected_owner: str,
+) -> None:
+    payload = {
+        "name": "python-runner",
+        "version": "2.0.0",
+        "description": "Run Python",
+        "runtime_type": "docker",
+        "image": "python:3.12",
+        "resource_limits": {"memory_mb": 512},
+        "runtime_config": {"workdir": "/workspace"},
+        "network_policy": "restricted",
+    }
+    if owner is not None:
+        payload["owner"] = owner
+    loaded = dict(payload)
+    opener = mock_open()
+    load_json = MagicMock(return_value=loaded)
+    post = MagicMock(return_value={"id": "sandbox-id", "qualified_name": "alice/python-runner"})
+    monkeypatch.setattr("builtins.open", opener)
+    monkeypatch.setattr(cmd_sandbox._json, "load", load_json)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", "--from-file", "sandbox.json")
+
+    assert result.exit_code == 0, result.output
+    assert "Sandbox submitted!" in result.output
+    assert "observal registry sandbox install alice/python-runner" in result.output
+    opener.assert_called_once_with("sandbox.json")
+    load_json.assert_called_once_with(opener.return_value.__enter__.return_value)
+    post.assert_called_once_with(
+        "/api/v1/sandboxes/submit",
+        {**payload, "owner": expected_owner, "visibility": "public"},
+    )
+    assert _boundaries["config_load"].call_count == (1 if owner is None else 0)
+
+
+@pytest.mark.parametrize("failure", ["missing", "invalid-json"])
+def test_submit_from_file_reports_filesystem_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    opener = mock_open()
+    if failure == "missing":
+        opener.side_effect = FileNotFoundError
+    else:
+        monkeypatch.setattr(
+            cmd_sandbox._json,
+            "load",
+            MagicMock(side_effect=json.JSONDecodeError("bad document", "{", 1)),
+        )
+    post = MagicMock()
+    monkeypatch.setattr("builtins.open", opener)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", "--from-file", "sandbox.json")
+
+    assert result.exit_code == 1
+    expected = "File not found" if failure == "missing" else "Invalid JSON in sandbox.json"
+    assert expected in result.output
+    post.assert_not_called()
+
+
+def test_submit_flags_post_complete_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    post = MagicMock(return_value={"id": "sandbox-id", "qualified_name": "alice/node-runner"})
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke(
+        "submit",
+        "--name",
+        "node-runner",
+        "--version",
+        "3.1.0",
+        "--description",
+        "Run Node tests",
+        "--runtime-type",
+        "docker",
+        "--image",
+        "node:22-alpine",
+        "--resource-limits",
+        '{"timeout":90,"memory_mb":1024}',
+        "--runtime-config",
+        '{"workdir":"/repo"}',
+        "--network-policy",
+        "restricted",
+        "--entrypoint",
+        "npm test",
+        "--harness",
+        "claude-code",
+        "--harness",
+        "pi",
+        "--source-url",
+        "https://github.com/acme/sandboxes",
+        "--source-ref",
+        "v3.1.0",
+        "--sandbox-path",
+        "node",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Sandbox submitted!" in result.output
+    assert "sandbox-id" in result.output
+    post.assert_called_once_with(
+        "/api/v1/sandboxes/submit",
+        {
+            "name": "node-runner",
+            "version": "3.1.0",
+            "description": "Run Node tests",
+            "owner": "alice",
+            "runtime_type": "docker",
+            "image": "node:22-alpine",
+            "resource_limits": {"timeout": 90, "memory_mb": 1024},
+            "runtime_config": {"workdir": "/repo"},
+            "network_policy": "restricted",
+            "supported_harnesses": ["claude-code", "pi"],
+            "entrypoint": "npm test",
+            "source_url": "https://github.com/acme/sandboxes",
+            "source_ref": "v3.1.0",
+            "sandbox_path": "node",
+            "visibility": "public",
+        },
+    )
+
+
+def test_submit_draft_targets_a_teamspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve_team = MagicMock(return_value="team-id")
+    post = MagicMock(return_value={"id": "draft-id", "qualified_name": "platform/runner"})
+    monkeypatch.setattr(client, "resolve_team_id", resolve_team)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", *VALID_SUBMIT, "--draft", "--team", "@Platform", "--visibility", "team")
+
+    assert result.exit_code == 0, result.output
+    assert "Draft saved!" in result.output
+    resolve_team.assert_called_once_with("@Platform")
+    post.assert_called_once_with(
+        "/api/v1/sandboxes/draft",
+        {
+            "name": "runner",
+            "version": "1.0.0",
+            "description": "Run tests",
+            "owner": "alice",
+            "runtime_type": "docker",
+            "image": "python:3.12",
+            "resource_limits": {},
+            "runtime_config": {},
+            "network_policy": "none",
+            "supported_harnesses": [],
+            "visibility": "team",
+            "team_id": "team-id",
+        },
+    )
+
+
+def test_submit_interactive_uses_prompt_boundaries(monkeypatch: pytest.MonkeyPatch) -> None:
+    text_input = MagicMock(
+        side_effect=[
+            "interactive-runner",
+            "1.4.0",
+            "Interactive sandbox",
+            "python:3.12",
+            '{"timeout":45}',
+            '{"workdir":"/src"}',
+        ]
+    )
+    select_one = MagicMock(return_value="docker")
+    post = MagicMock(return_value={"id": "sandbox-id", "qualified_name": "alice/interactive-runner"})
+    monkeypatch.setattr(cmd_sandbox, "text_input", text_input)
+    monkeypatch.setattr(cmd_sandbox, "select_one", select_one)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit")
+
+    assert result.exit_code == 0, result.output
+    text_input.assert_has_calls(
+        [
+            call("Sandbox name"),
+            call("Version", default="1.0.0"),
+            call("Description"),
+            call("Image"),
+            call("Resource limits (JSON)"),
+            call("Runtime config (JSON)", default="{}"),
+        ]
+    )
+    select_one.assert_called_once_with("Runtime type", VALID_SANDBOX_RUNTIME_TYPES)
+    post.assert_called_once_with(
+        "/api/v1/sandboxes/submit",
+        {
+            "name": "interactive-runner",
+            "version": "1.4.0",
+            "description": "Interactive sandbox",
+            "owner": "alice",
+            "runtime_type": "docker",
+            "image": "python:3.12",
+            "resource_limits": {"timeout": 45},
+            "runtime_config": {"workdir": "/src"},
+            "visibility": "public",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (("--name", "runner"), "--name, --description, --runtime-type, and --image are required"),
+        ((*VALID_SUBMIT, "--runtime-type", "process"), "Invalid runtime type: process"),
+        ((*VALID_SUBMIT, "--network-policy", "internet"), "Invalid network policy: internet"),
+        ((*VALID_SUBMIT, "--harness", "unknown"), "Invalid harness: unknown"),
+    ],
+)
+def test_submit_validates_flag_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    args: tuple[str, ...],
+    message: str,
+) -> None:
+    post = MagicMock()
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", *args)
+
+    assert result.exit_code == 1
+    assert message in result.output
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize("option", ["--resource-limits", "--runtime-config"])
+def test_submit_rejects_malformed_json_options(monkeypatch: pytest.MonkeyPatch, option: str) -> None:
+    post = MagicMock()
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", *VALID_SUBMIT, option, "{")
+
+    assert result.exit_code == 1
+    assert "Invalid JSON option" in result.output
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "target_args",
+    [("--visibility", "internal"), ("--visibility", "team")],
+)
+def test_submit_validates_publish_target(
+    monkeypatch: pytest.MonkeyPatch,
+    target_args: tuple[str, ...],
+) -> None:
+    post = MagicMock()
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("submit", *VALID_SUBMIT, *target_args)
+
+    assert result.exit_code != 0
+    expected = "visibility must be" if target_args[-1] == "internal" else "requires --team"
+    assert expected in result.output
+    post.assert_not_called()
+
+
+def test_list_empty_result_is_visible_and_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    get = MagicMock(return_value=[])
+    save = MagicMock()
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(config, "save_last_results", save)
+
+    result = invoke("list")
+
+    assert result.exit_code == 0, result.output
+    assert "No sandboxes found." in result.output
+    get.assert_called_once_with("/api/v1/sandboxes", params={})
+    save.assert_not_called()
+
+
+def test_list_filters_and_json_output_use_exact_boundaries(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = [{"id": "sandbox-id", "name": "Runner", "version": "1.0.0"}]
+    resolve_team = MagicMock(return_value="team-id")
+    get = MagicMock(return_value=data)
+    save = MagicMock()
+    output_json = MagicMock()
+    monkeypatch.setattr(client, "resolve_team_id", resolve_team)
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(config, "save_last_results", save)
+    monkeypatch.setattr(cmd_sandbox, "output_json", output_json)
+
+    result = invoke(
+        "list",
+        "--runtime",
+        "docker",
+        "--search",
+        "python",
+        "--namespace",
+        "@Alice",
+        "--team",
+        "platform",
+        "--output",
+        "json",
+    )
+
+    assert result.exit_code == 0, result.output
+    resolve_team.assert_called_once_with("platform")
+    get.assert_called_once_with(
+        "/api/v1/sandboxes",
+        params={"runtime": "docker", "search": "python", "namespace": "alice", "team_id": "team-id"},
+    )
+    save.assert_called_once_with(data)
+    output_json.assert_called_once_with(data)
+
+
+def test_list_plain_output_renders_each_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = [
+        {"id": "one", "name": "Runner", "version": "2.0.0"},
+        {"id": "two", "name": "Minimal"},
+    ]
+    get = MagicMock(return_value=data)
+    save = MagicMock()
+    name_inline = MagicMock(side_effect=["runner [dim]@alice[/dim]", "minimal"])
+    rprint = MagicMock()
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(config, "save_last_results", save)
+    monkeypatch.setattr(cmd_sandbox, "name_inline", name_inline)
+    monkeypatch.setattr(cmd_sandbox, "rprint", rprint)
+
+    result = invoke("list", "--output", "plain")
+
+    assert result.exit_code == 0, result.output
+    get.assert_called_once_with("/api/v1/sandboxes", params={})
+    save.assert_called_once_with(data)
+    assert rprint.call_args_list == [
+        call("one  runner [dim]@alice[/dim]  v2.0.0"),
+        call("two  minimal  v?"),
+    ]
+
+
+def test_list_table_builds_exact_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = [
+        {
+            "id": "123456789abcdef",
+            "slug": "runner",
+            "namespace": "alice",
+            "version": "2.0.0",
+            "status": "approved",
+        }
+    ]
+    table = MagicMock()
+    table_type = MagicMock(return_value=table)
+    console_print = MagicMock()
+    get = MagicMock(return_value=data)
+    save = MagicMock()
+    display_name = MagicMock(return_value="runner")
+    handle = MagicMock(return_value="@alice")
+    status_badge = MagicMock(return_value="APPROVED")
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(config, "save_last_results", save)
+    monkeypatch.setattr(cmd_sandbox, "Table", table_type)
+    monkeypatch.setattr(cmd_sandbox.console, "print", console_print)
+    monkeypatch.setattr(cmd_sandbox, "display_name", display_name)
+    monkeypatch.setattr(cmd_sandbox, "handle", handle)
+    monkeypatch.setattr(cmd_sandbox, "status_badge", status_badge)
+
+    result = invoke("list")
+
+    assert result.exit_code == 0, result.output
+    table_type.assert_called_once_with(title="Sandboxes (1)", show_lines=False, padding=(0, 1))
+    assert table.add_column.call_args_list == [
+        call("#", style="dim", width=3),
+        call("Name", style="bold cyan", no_wrap=True),
+        call("Version", style="green"),
+        call("Namespace", style="dim"),
+        call("Status"),
+        call("ID", style="dim", max_width=12),
+    ]
+    table.add_row.assert_called_once_with("1", "runner", "2.0.0", "@alice", "APPROVED", "12345678…")
+    console_print.assert_called_once_with(table)
+    save.assert_called_once_with(data)
+
+
+def test_show_json_resolves_alias_and_uses_json_renderer(monkeypatch: pytest.MonkeyPatch) -> None:
+    item = {"id": "sandbox-id", "name": "Runner"}
+    resolve = MagicMock(return_value="sandbox-id")
+    get = MagicMock(return_value=item)
+    output_json = MagicMock()
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(cmd_sandbox, "output_json", output_json)
+
+    result = invoke("show", "@runner", "--output", "json")
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with("sandbox", "@runner")
+    get.assert_called_once_with("/api/v1/sandboxes/sandbox-id")
+    output_json.assert_called_once_with(item)
+
+
+def test_show_table_builds_exact_detail_panel(monkeypatch: pytest.MonkeyPatch) -> None:
+    item = {
+        "id": "sandbox-id",
+        "slug": "runner",
+        "namespace": "platform",
+        "version": "2.0.0",
+        "status": "pending",
+        "runtime_type": "docker",
+        "image": "python:3.12",
+        "description": "Run tests",
+        "created_at": "2026-08-01T00:00:00Z",
+    }
+    resolve = MagicMock(return_value="sandbox-id")
+    get = MagicMock(return_value=item)
+    display_name = MagicMock(return_value="runner")
+    status_badge = MagicMock(return_value="PENDING")
+    handle = MagicMock(return_value="@platform")
+    relative_time = MagicMock(return_value="8d ago")
+    panel = object()
+    kv_panel = MagicMock(return_value=panel)
+    console_print = MagicMock()
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(cmd_sandbox, "display_name", display_name)
+    monkeypatch.setattr(cmd_sandbox, "status_badge", status_badge)
+    monkeypatch.setattr(cmd_sandbox, "handle", handle)
+    monkeypatch.setattr(cmd_sandbox, "relative_time", relative_time)
+    monkeypatch.setattr(cmd_sandbox, "kv_panel", kv_panel)
+    monkeypatch.setattr(cmd_sandbox.console, "print", console_print)
+
+    result = invoke("show", "platform/runner")
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with("sandbox", "platform/runner")
+    get.assert_called_once_with("/api/v1/sandboxes/sandbox-id")
+    kv_panel.assert_called_once_with(
+        "runner v2.0.0",
+        [
+            ("Status", "PENDING"),
+            ("Runtime", "docker"),
+            ("Image", "python:3.12"),
+            ("Namespace", "@platform"),
+            ("Description", "Run tests"),
+            ("Created", "8d ago"),
+            ("ID", "[dim]sandbox-id[/dim]"),
+        ],
+        border_style="red",
+    )
+    console_print.assert_called_once_with(panel)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [("my",), ("install", "runner", "--harness", "pi")],
+    ids=["my", "install"],
+)
+def test_removed_sandbox_commands_are_not_registered(args: tuple[str, ...]) -> None:
+    result = invoke(*args)
+
+    assert result.exit_code == 2
+    assert f"No such command '{args[0]}'" in result.output
+
+
+def test_edit_flags_acquire_lock_and_put_exact_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    post = MagicMock(return_value={})
+    put = MagicMock(return_value={"name": "renamed", "status": "draft"})
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+    monkeypatch.setattr(client, "put", put)
+
+    result = invoke(
+        "edit",
+        "@runner",
+        "--name",
+        "renamed",
+        "--description",
+        "Updated",
+        "--version",
+        "2.1.0",
+        "--runtime-type",
+        "lxc",
+        "--image",
+        "images:ubuntu/24.04",
+        "--resource-limits",
+        '{"cpu_count":2}',
+        "--runtime-config",
+        '{"profile":"safe"}',
+        "--network-policy",
+        "restricted",
+        "--entrypoint",
+        "pytest",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Updated renamed (status: draft)" in result.output
+    resolve.assert_called_once_with("sandbox", "@runner")
+    post.assert_called_once_with("/api/v1/sandboxes/sandbox-id/start-edit")
+    put.assert_called_once_with(
+        "/api/v1/sandboxes/sandbox-id/draft",
+        {
+            "name": "renamed",
+            "description": "Updated",
+            "version": "2.1.0",
+            "runtime_type": "lxc",
+            "image": "images:ubuntu/24.04",
+            "resource_limits": {"cpu_count": 2},
+            "runtime_config": {"profile": "safe"},
+            "network_policy": "restricted",
+            "entrypoint": "pytest",
+        },
+    )
+
+
+def test_edit_from_file_puts_exact_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    updates = {"image": "python:3.13", "runtime_config": {"workdir": "/work"}}
+    opener = mock_open()
+    load_json = MagicMock(return_value=updates)
+    resolve = MagicMock(return_value="sandbox-id")
+    post = MagicMock(return_value={})
+    put = MagicMock(return_value={"name": "runner", "status": "pending"})
+    monkeypatch.setattr("builtins.open", opener)
+    monkeypatch.setattr(cmd_sandbox._json, "load", load_json)
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+    monkeypatch.setattr(client, "put", put)
+
+    result = invoke("edit", "1", "--from-file", "updates.json")
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with("sandbox", "1")
+    opener.assert_called_once_with("updates.json")
+    post.assert_called_once_with("/api/v1/sandboxes/sandbox-id/start-edit")
+    put.assert_called_once_with("/api/v1/sandboxes/sandbox-id/draft", updates)
+
+
+@pytest.mark.parametrize("failure", ["missing", "invalid-json"])
+def test_edit_from_file_reports_filesystem_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    opener = mock_open()
+    if failure == "missing":
+        opener.side_effect = FileNotFoundError
+    else:
+        monkeypatch.setattr(
+            cmd_sandbox._json,
+            "load",
+            MagicMock(side_effect=json.JSONDecodeError("bad document", "{", 1)),
+        )
+    resolve = MagicMock(return_value="sandbox-id")
+    post = MagicMock()
+    monkeypatch.setattr("builtins.open", opener)
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("edit", "runner", "--from-file", "updates.json")
+
+    assert result.exit_code == 1
+    expected = "File not found" if failure == "missing" else "Invalid JSON in updates.json"
+    assert expected in result.output
+    resolve.assert_called_once_with("sandbox", "runner")
+    post.assert_not_called()
+
+
+def test_edit_without_updates_stops_before_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    post = MagicMock()
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("edit", "runner")
+
+    assert result.exit_code == 1
+    assert "No changes specified" in result.output
+    resolve.assert_called_once_with("sandbox", "runner")
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize("message", ["409 Conflict", "sandbox is currently being edited by bob"])
+def test_edit_lock_conflict_is_visible(
+    monkeypatch: pytest.MonkeyPatch,
+    message: str,
+) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    post = MagicMock(side_effect=RuntimeError(message))
+    put = MagicMock()
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+    monkeypatch.setattr(client, "put", put)
+
+    result = invoke("edit", "runner", "--description", "Changed")
+
+    assert result.exit_code == 1
+    assert "Cannot edit" in result.output
+    assert message in result.output
+    post.assert_called_once_with("/api/v1/sandboxes/sandbox-id/start-edit")
+    put.assert_not_called()
+
+
+@pytest.mark.parametrize("cancel_fails", [False, True])
+def test_edit_save_failure_attempts_lock_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    cancel_fails: bool,
+) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    post = MagicMock(side_effect=[{}, RuntimeError("cancel unavailable")] if cancel_fails else None)
+    put = MagicMock(side_effect=RuntimeError("HTTP 503 while saving"))
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "post", post)
+    monkeypatch.setattr(client, "put", put)
+
+    result = invoke("edit", "runner", "--image", "python:3.13")
+
+    assert result.exit_code == 1
+    assert "Failed to update" in result.output
+    assert "HTTP 503 while saving" in result.output
+    assert post.call_args_list == [
+        call("/api/v1/sandboxes/sandbox-id/start-edit"),
+        call("/api/v1/sandboxes/sandbox-id/cancel-edit"),
+    ]
+    put.assert_called_once_with("/api/v1/sandboxes/sandbox-id/draft", {"image": "python:3.13"})
+
+
+def test_archive_yes_resolves_reference_without_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    get = MagicMock()
+    patch_request = MagicMock(return_value={})
+    confirm = MagicMock()
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(client, "patch", patch_request)
+    monkeypatch.setattr("observal_cli.cmd_archive.typer.confirm", confirm)
+
+    result = invoke("archive", "platform/runner", "--yes")
+
+    assert result.exit_code == 0, result.output
+    assert "Sandbox archived" in result.output
+    resolve.assert_called_once_with("sandboxes", "platform/runner")
+    get.assert_not_called()
+    confirm.assert_not_called()
+    patch_request.assert_called_once_with("/api/v1/sandboxes/sandbox-id/archive")
+
+
+def test_unarchive_confirms_and_restores(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    get = MagicMock(return_value={"name": "Runner"})
+    patch_request = MagicMock(return_value={})
+    confirm = MagicMock(return_value=True)
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(client, "patch", patch_request)
+    monkeypatch.setattr("observal_cli.cmd_archive.typer.confirm", confirm)
+
+    result = invoke("unarchive", "@runner")
+
+    assert result.exit_code == 0, result.output
+    assert "Sandbox restored" in result.output
+    resolve.assert_called_once_with("sandboxes", "@runner")
+    get.assert_called_once_with("/api/v1/sandboxes/sandbox-id")
+    confirm.assert_called_once_with("Restore sandbox [bold]Runner[/bold] (sandbox-id)?")
+    patch_request.assert_called_once_with("/api/v1/sandboxes/sandbox-id/unarchive")
+
+
+def test_archive_cancellation_does_not_mutate(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolve = MagicMock(return_value="sandbox-id")
+    get = MagicMock(return_value={"name": "Runner"})
+    patch_request = MagicMock()
+    confirm = MagicMock(return_value=False)
+    monkeypatch.setattr(client, "resolve_registry_reference", resolve)
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr(client, "patch", patch_request)
+    monkeypatch.setattr("observal_cli.cmd_archive.typer.confirm", confirm)
+
+    result = invoke("archive", "runner")
+
+    assert result.exit_code == 1
+    confirm.assert_called_once_with("Archive sandbox [bold]Runner[/bold] (sandbox-id)?")
+    patch_request.assert_not_called()
+
+
+def test_co_author_list_renders_exact_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    authors = [{"email": "bob@example.com", "username": "bob", "is_active": False}]
+    get = MagicMock(return_value=authors)
+    table = MagicMock()
+    table_type = MagicMock(return_value=table)
+    rprint = MagicMock()
+    monkeypatch.setattr(client, "get", get)
+    monkeypatch.setattr("observal_cli.cmd_co_authors.Table", table_type)
+    monkeypatch.setattr("observal_cli.cmd_co_authors.rprint", rprint)
+
+    result = invoke("co-authors", "list", "sandbox-id")
+
+    assert result.exit_code == 0, result.output
+    get.assert_called_once_with("/sandboxes/sandbox-id/co-authors")
+    table_type.assert_called_once_with(title="Co-Authors")
+    assert table.add_column.call_args_list == [
+        call("Email", style="cyan"),
+        call("Username", style="green"),
+        call("Active", style="dim"),
+    ]
+    table.add_row.assert_called_once_with("bob@example.com", "bob", "no")
+    rprint.assert_called_once_with(table)
+
+
+@pytest.mark.parametrize(
+    ("user", "body"),
+    [("Bob@Example.COM", {"email": "bob@example.com"}), ("@Bob", {"username": "Bob"})],
+)
+def test_co_author_add_normalizes_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    user: str,
+    body: dict[str, str],
+) -> None:
+    post = MagicMock(return_value={"email": "bob@example.com", "username": "bob"})
+    monkeypatch.setattr(client, "post", post)
+
+    result = invoke("co-authors", "add", "sandbox-id", user)
+
+    assert result.exit_code == 0, result.output
+    assert "Added co-author" in result.output
+    post.assert_called_once_with("/sandboxes/sandbox-id/co-authors", json_data=body)
+
+
+def test_co_author_remove_calls_exact_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    delete = MagicMock(return_value={})
+    monkeypatch.setattr(client, "delete", delete)
+
+    result = invoke("co-authors", "remove", "sandbox-id", "user-id")
+
+    assert result.exit_code == 0, result.output
+    assert "Co-author removed" in result.output
+    delete.assert_called_once_with("/sandboxes/sandbox-id/co-authors/user-id")

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1,0 +1,838 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral coverage for the local sandbox runtime dispatcher."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from observal_cli import sandbox_runner
+
+
+@pytest.fixture(autouse=True)
+def _isolated_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OBSERVAL_KEY", raising=False)
+    monkeypatch.delenv("OBSERVAL_SERVER", raising=False)
+
+
+def _docker_sdk(container: MagicMock) -> tuple[MagicMock, MagicMock]:
+    client = MagicMock()
+    client.containers.run.return_value = container
+    docker = MagicMock()
+    docker.from_env.return_value = client
+    return docker, client
+
+
+def test_time_and_log_helpers_have_exact_contracts(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixed = datetime(2026, 8, 9, 10, 11, 12, 987654, tzinfo=UTC)
+    now = MagicMock(return_value=fixed)
+    monkeypatch.setattr(sandbox_runner, "datetime", SimpleNamespace(now=now))
+
+    assert sandbox_runner._now_iso() == "2026-08-09 10:11:12.987"
+    now.assert_called_once_with(UTC)
+    assert sandbox_runner._send_span("server", "token", {"span_id": "span"}) is None
+
+    boundary = "x" * sandbox_runner.MAX_LOG_BYTES
+    assert sandbox_runner._truncate(boundary) == boundary
+    assert sandbox_runner._truncate(boundary + "tail") == boundary + "\n... [truncated at 64KB]"
+
+
+def test_require_bin_returns_resolved_executable(monkeypatch: pytest.MonkeyPatch) -> None:
+    which = MagicMock(return_value="/opt/bin/wasmtime")
+    monkeypatch.setattr(sandbox_runner.shutil, "which", which)
+
+    assert sandbox_runner._require_bin("wasmtime") == "/opt/bin/wasmtime"
+    which.assert_called_once_with("wasmtime")
+
+
+def test_require_bin_reports_exact_missing_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    which = MagicMock(return_value=None)
+    monkeypatch.setattr(sandbox_runner.shutil, "which", which)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._require_bin("lxc")
+
+    assert raised.value.code == 127
+    assert capsys.readouterr() == ("", "local-runtime-missing: lxc is not installed or not on PATH\n")
+    which.assert_called_once_with("lxc")
+
+
+def test_run_subprocess_captures_combines_emits_and_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    completed = SimpleNamespace(stdout="standard output", stderr="standard error", returncode=23)
+    run = MagicMock(return_value=completed)
+    monkeypatch.setattr(sandbox_runner.subprocess, "run", run)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._run_subprocess(["/bin/tool", "arg"], 17)
+
+    assert raised.value.code == 23
+    assert capsys.readouterr() == ("standard output\n[stderr]\nstandard error", "")
+    run.assert_called_once_with(["/bin/tool", "arg"], capture_output=True, text=True, timeout=17)
+
+
+def test_run_subprocess_preserves_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    timeout = subprocess.TimeoutExpired(["tool"], 3)
+    run = MagicMock(side_effect=timeout)
+    monkeypatch.setattr(sandbox_runner.subprocess, "run", run)
+
+    with pytest.raises(subprocess.TimeoutExpired) as raised:
+        sandbox_runner._run_subprocess(["tool"], 3)
+
+    assert raised.value is timeout
+    assert capsys.readouterr() == ("", "")
+    run.assert_called_once_with(["tool"], capture_output=True, text=True, timeout=3)
+
+
+def test_docker_missing_sdk_is_an_actionable_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setitem(sys.modules, "docker", None)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._docker_run("sandbox", "image", None, 10, None, "none", {})
+
+    assert raised.value.code == 127
+    assert capsys.readouterr() == (
+        "",
+        "local-runtime-missing: Docker SDK not found. Install: pip install 'observal-cli[sandbox]'\n",
+    )
+
+
+def test_docker_client_creation_failure_propagates_before_lifecycle_management(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    failure = RuntimeError("daemon unavailable")
+    docker = MagicMock()
+    docker.from_env.side_effect = failure
+    monkeypatch.setitem(sys.modules, "docker", docker)
+
+    with pytest.raises(RuntimeError) as raised:
+        sandbox_runner._docker_run("id", "image", None, 10, None, "none", {})
+
+    assert raised.value is failure
+    assert capsys.readouterr() == ("", "")
+    docker.from_env.assert_called_once_with()
+
+
+def test_docker_run_builds_limits_emits_logs_sends_span_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    events: list[object] = []
+    container = MagicMock()
+    container.wait.side_effect = lambda **kwargs: events.append(("wait", kwargs)) or {"StatusCode": 0}
+    container.logs.side_effect = lambda **kwargs: events.append(("logs", kwargs)) or b"hello\xff"
+    container.reload.side_effect = lambda: events.append("reload")
+    container.remove.side_effect = lambda **kwargs: events.append(("remove", kwargs))
+    container.short_id = "c0ffee"
+    container.attrs = {"State": {"OOMKilled": True}}
+    docker, client = _docker_sdk(container)
+
+    def run_container(**kwargs):
+        events.append(("run", kwargs))
+        return container
+
+    client.containers.run.side_effect = run_container
+    monotonic = MagicMock(side_effect=[100.0, 100.125])
+    now_iso = MagicMock(side_effect=["2026-08-09 10:00:00.000", "2026-08-09 10:00:00.125"])
+    send_span = MagicMock(side_effect=lambda *_args: events.append("span"))
+    load_config = MagicMock(side_effect=AssertionError("config must not be loaded when environment credentials exist"))
+    monkeypatch.setitem(sys.modules, "docker", docker)
+    monkeypatch.setattr(sandbox_runner.time, "monotonic", monotonic)
+    monkeypatch.setattr(sandbox_runner, "_now_iso", now_iso)
+    monkeypatch.setattr(sandbox_runner, "_send_span", send_span)
+    monkeypatch.setattr(sandbox_runner, "load_config", load_config)
+    monkeypatch.setattr(
+        sandbox_runner.uuid,
+        "uuid4",
+        MagicMock(side_effect=[uuid.UUID(int=1), uuid.UUID(int=2)]),
+    )
+    monkeypatch.setenv("OBSERVAL_KEY", "environment-token")
+    monkeypatch.setenv("OBSERVAL_SERVER", "https://registry.example")
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._docker_run(
+            "sandbox-id",
+            "python:3.13",
+            "python -m pytest",
+            45,
+            {"TOKEN": "value", "PATH": "/sandbox/bin"},
+            "restricted",
+            {"memory_mb": "512", "cpu_count": "1.5"},
+        )
+
+    assert raised.value.code == 0
+    assert capsys.readouterr() == ("hello�", "")
+    docker.from_env.assert_called_once_with()
+    expected_run_kwargs = {
+        "image": "python:3.13",
+        "detach": True,
+        "environment": {"TOKEN": "value", "PATH": "/sandbox/bin"},
+        "stdout": True,
+        "stderr": True,
+        "command": "python -m pytest",
+        "network_mode": "none",
+        "mem_limit": "512m",
+        "nano_cpus": 1_500_000_000,
+    }
+    assert events == [
+        ("run", expected_run_kwargs),
+        ("wait", {"timeout": 45}),
+        ("logs", {"stdout": True, "stderr": True}),
+        "reload",
+        "span",
+        ("remove", {"force": True}),
+    ]
+    send_span.assert_called_once_with(
+        "https://registry.example",
+        "environment-token",
+        {
+            "span_id": str(uuid.UUID(int=1)),
+            "trace_id": str(uuid.UUID(int=2)),
+            "parent_span_id": None,
+            "type": "sandbox_exec",
+            "name": "sandbox:python:3.13",
+            "method": "",
+            "input": json.dumps({"image": "python:3.13", "command": "python -m pytest", "sandbox_id": "sandbox-id"}),
+            "output": "hello�",
+            "error": None,
+            "start_time": "2026-08-09 10:00:00.000",
+            "end_time": "2026-08-09 10:00:00.125",
+            "latency_ms": 125,
+            "status": "success",
+            "harness": "",
+            "metadata": {},
+            "container_id": "c0ffee",
+            "exit_code": 0,
+            "oom_killed": True,
+        },
+    )
+    load_config.assert_not_called()
+
+
+def test_docker_run_uses_config_fallback_and_error_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    container = MagicMock()
+    container.wait.return_value = {}
+    container.logs.return_value = "failed"
+    container.short_id = "deadbeef"
+    container.attrs = {}
+    docker, client = _docker_sdk(container)
+    send_span = MagicMock()
+    load_config = MagicMock(return_value={"access_token": "config-token", "server_url": "https://config.example"})
+    monkeypatch.setitem(sys.modules, "docker", docker)
+    monkeypatch.setattr(sandbox_runner, "_send_span", send_span)
+    monkeypatch.setattr(sandbox_runner, "load_config", load_config)
+    monkeypatch.setattr(sandbox_runner.time, "monotonic", MagicMock(side_effect=[5.0, 5.0]))
+    monkeypatch.setenv("OBSERVAL_KEY", "environment-token")
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._docker_run("id", "image", None, 9, None, "invalid", {"memory_mb": 0, "cpu_count": 0})
+
+    assert raised.value.code == -1
+    assert capsys.readouterr() == ("failed", "")
+    client.containers.run.assert_called_once_with(
+        image="image",
+        detach=True,
+        environment={},
+        stdout=True,
+        stderr=True,
+    )
+    load_config.assert_called_once_with()
+    assert send_span.call_args.args[:2] == ("https://config.example", "environment-token")
+    span = send_span.call_args.args[2]
+    assert span["error"] == "exit_code=-1"
+    assert span["status"] == "error"
+    assert span["exit_code"] == -1
+    assert span["oom_killed"] is False
+    container.remove.assert_called_once_with(force=True)
+
+
+@pytest.mark.parametrize(
+    ("network_policy", "expected_mode"),
+    [("host", "host"), ("restricted", "none"), ("custom", None)],
+)
+def test_docker_network_policy_mapping_on_start_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    network_policy: str,
+    expected_mode: str | None,
+) -> None:
+    container = MagicMock()
+    docker, client = _docker_sdk(container)
+    client.containers.run.side_effect = RuntimeError("start failed")
+    monkeypatch.setitem(sys.modules, "docker", docker)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._docker_run("id", "image", None, 10, None, network_policy, {})
+
+    assert raised.value.code == 1
+    assert capsys.readouterr() == ("", "Error: start failed\n")
+    kwargs = client.containers.run.call_args.kwargs
+    if expected_mode is None:
+        assert "network_mode" not in kwargs
+    else:
+        assert kwargs["network_mode"] == expected_mode
+    container.remove.assert_not_called()
+
+
+def test_docker_runtime_error_keeps_error_and_attempts_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    container = MagicMock()
+    container.wait.side_effect = RuntimeError("wait failed")
+    container.remove.side_effect = RuntimeError("cleanup failed")
+    docker, _client = _docker_sdk(container)
+    monkeypatch.setitem(sys.modules, "docker", docker)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._docker_run("id", "image", None, 10, None, "none", {})
+
+    assert raised.value.code == 1
+    assert capsys.readouterr() == ("", "Error: wait failed\n")
+    container.remove.assert_called_once_with(force=True)
+
+
+def test_docker_interrupt_is_preserved_after_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    container = MagicMock()
+    interrupt = KeyboardInterrupt()
+    container.wait.side_effect = interrupt
+    docker, _client = _docker_sdk(container)
+    monkeypatch.setitem(sys.modules, "docker", docker)
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        sandbox_runner._docker_run("id", "image", None, 10, None, "none", {})
+
+    assert raised.value is interrupt
+    assert capsys.readouterr() == ("", "")
+    container.remove.assert_called_once_with(force=True)
+
+
+def test_docker_rejects_invalid_resource_limit_before_start(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    container = MagicMock()
+    docker, client = _docker_sdk(container)
+    monkeypatch.setitem(sys.modules, "docker", docker)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._docker_run("id", "image", None, 10, None, "none", {"memory_mb": "many"})
+
+    assert raised.value.code == 1
+    assert capsys.readouterr() == ("", "Error: invalid literal for int() with base 10: 'many'\n")
+    client.containers.run.assert_not_called()
+
+
+@pytest.mark.parametrize(("command", "expected_command"), [(None, "sh"), ("echo hello", "echo hello")])
+def test_lxc_builds_launch_exec_and_delete_commands_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+    command: str | None,
+    expected_command: str,
+) -> None:
+    events: list[object] = []
+    require_bin = MagicMock(return_value="/opt/lxc")
+    run = MagicMock(side_effect=lambda argv, **kwargs: events.append(("subprocess", argv, kwargs)))
+    worker_exit = SystemExit(7)
+
+    def execute(argv, timeout):
+        events.append(("execute", argv, timeout))
+        raise worker_exit
+
+    monkeypatch.setattr(sandbox_runner, "_require_bin", require_bin)
+    monkeypatch.setattr(sandbox_runner.uuid, "uuid4", MagicMock(return_value=SimpleNamespace(hex="12345678abcdef")))
+    monkeypatch.setattr(sandbox_runner.subprocess, "run", run)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._lxc_run("abcdef12-rest", "images:ubuntu/24.04", command, 31)
+
+    assert raised.value is worker_exit
+    name = "observal-abcdef12-12345678"
+    assert events == [
+        (
+            "subprocess",
+            ["/opt/lxc", "launch", "images:ubuntu/24.04", name, "--ephemeral"],
+            {"check": True, "timeout": 31},
+        ),
+        ("execute", ["/opt/lxc", "exec", name, "--", "sh", "-lc", expected_command], 31),
+        (
+            "subprocess",
+            ["/opt/lxc", "delete", name, "--force"],
+            {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL},
+        ),
+    ]
+    require_bin.assert_called_once_with("lxc")
+
+
+def test_lxc_launch_failure_is_preserved_without_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    failure = subprocess.TimeoutExpired(["lxc", "launch"], 4)
+    run = MagicMock(side_effect=failure)
+    execute = MagicMock()
+    monkeypatch.setattr(sandbox_runner, "_require_bin", MagicMock(return_value="lxc"))
+    monkeypatch.setattr(sandbox_runner.uuid, "uuid4", MagicMock(return_value=SimpleNamespace(hex="abcdef12")))
+    monkeypatch.setattr(sandbox_runner.subprocess, "run", run)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+
+    with pytest.raises(subprocess.TimeoutExpired) as raised:
+        sandbox_runner._lxc_run("id", "image", "command", 4)
+
+    assert raised.value is failure
+    assert run.call_count == 1
+    execute.assert_not_called()
+
+
+def test_lxc_delete_failure_replaces_workload_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    workload_exit = SystemExit(9)
+    cleanup_failure = RuntimeError("delete failed")
+    run = MagicMock(side_effect=[None, cleanup_failure])
+    monkeypatch.setattr(sandbox_runner, "_require_bin", MagicMock(return_value="lxc"))
+    monkeypatch.setattr(sandbox_runner.uuid, "uuid4", MagicMock(return_value=SimpleNamespace(hex="abcdef12")))
+    monkeypatch.setattr(sandbox_runner.subprocess, "run", run)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", MagicMock(side_effect=workload_exit))
+
+    with pytest.raises(RuntimeError) as raised:
+        sandbox_runner._lxc_run("id", "image", "command", 8)
+
+    assert raised.value is cleanup_failure
+    assert run.call_count == 2
+
+
+def test_lxc_interrupt_runs_delete_then_preserves_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+    interrupt = KeyboardInterrupt()
+    run = MagicMock(side_effect=lambda *_args, **_kwargs: events.append("launch" if not events else "delete"))
+
+    def execute(*_args, **_kwargs):
+        events.append("execute")
+        raise interrupt
+
+    monkeypatch.setattr(sandbox_runner, "_require_bin", MagicMock(return_value="lxc"))
+    monkeypatch.setattr(sandbox_runner.uuid, "uuid4", MagicMock(return_value=SimpleNamespace(hex="abcdef12")))
+    monkeypatch.setattr(sandbox_runner.subprocess, "run", run)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        sandbox_runner._lxc_run("id", "image", "command", 8)
+
+    assert raised.value is interrupt
+    assert events == ["launch", "execute", "delete"]
+
+
+def test_firecracker_requires_a_complete_generated_config(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sandbox_runner, "_require_bin", MagicMock(return_value="/bin/firecracker"))
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._firecracker_run({"kernel_image_path": "/kernel"}, 10)
+
+    assert raised.value.code == 2
+    assert capsys.readouterr() == (
+        "",
+        "Firecracker requires runtime_config.config_path or kernel_image_path/rootfs_path\n",
+    )
+
+
+def test_firecracker_uses_existing_config_without_temporary_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    execute = MagicMock(return_value=None)
+    named_temporary_file = MagicMock(side_effect=AssertionError("temporary file must not be created"))
+    unlink = MagicMock()
+    monkeypatch.setattr(sandbox_runner, "_require_bin", MagicMock(return_value="/opt/firecracker"))
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+    monkeypatch.setattr(sandbox_runner.tempfile, "NamedTemporaryFile", named_temporary_file)
+    monkeypatch.setattr(sandbox_runner.os, "unlink", unlink)
+
+    assert sandbox_runner._firecracker_run({"config_path": Path("machine.json")}, 22) is None
+
+    execute.assert_called_once_with(["/opt/firecracker", "--config-file", "machine.json"], 22)
+    named_temporary_file.assert_not_called()
+    unlink.assert_not_called()
+
+
+@pytest.mark.parametrize("cleanup_error", [None, OSError("already removed")])
+def test_firecracker_writes_exact_generated_config_and_always_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_error: OSError | None,
+) -> None:
+    events: list[object] = []
+    temporary = io.StringIO()
+    temporary.name = "/tmp/firecracker-config.json"
+    context = MagicMock()
+    context.__enter__.return_value = temporary
+    named_temporary_file = MagicMock(return_value=context)
+    worker_exit = SystemExit(124)
+
+    def execute(argv, timeout):
+        events.append(("execute", argv, timeout))
+        raise worker_exit
+
+    def unlink(path):
+        events.append(("unlink", path))
+        if cleanup_error:
+            raise cleanup_error
+
+    monkeypatch.setattr(sandbox_runner, "_require_bin", MagicMock(return_value="firecracker"))
+    monkeypatch.setattr(sandbox_runner.tempfile, "NamedTemporaryFile", named_temporary_file)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+    monkeypatch.setattr(sandbox_runner.os, "unlink", unlink)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._firecracker_run(
+            {
+                "kernel_image_path": "/images/vmlinux",
+                "rootfs_path": "/images/rootfs.ext4",
+                "boot_args": "console=ttyS0 quiet",
+                "rootfs_read_only": 1,
+                "machine_config": {"vcpu_count": 2, "mem_size_mib": 512},
+            },
+            19,
+        )
+
+    assert raised.value is worker_exit
+    named_temporary_file.assert_called_once_with("w", suffix=".json", delete=False)
+    assert json.loads(temporary.getvalue()) == {
+        "boot-source": {"kernel_image_path": "/images/vmlinux", "boot_args": "console=ttyS0 quiet"},
+        "drives": [
+            {
+                "drive_id": "rootfs",
+                "path_on_host": "/images/rootfs.ext4",
+                "is_root_device": True,
+                "is_read_only": True,
+            }
+        ],
+        "machine-config": {"vcpu_count": 2, "mem_size_mib": 512},
+    }
+    assert events == [
+        ("execute", ["firecracker", "--config-file", "/tmp/firecracker-config.json"], 19),
+        ("unlink", "/tmp/firecracker-config.json"),
+    ]
+
+
+def test_wasm_builds_argument_vector_without_a_shell(monkeypatch: pytest.MonkeyPatch) -> None:
+    require_bin = MagicMock(return_value="/opt/wasmer")
+    execute = MagicMock(return_value=None)
+    monkeypatch.setattr(sandbox_runner, "_require_bin", require_bin)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+
+    assert (
+        sandbox_runner._wasm_run(
+            "ignored.wasm",
+            "--flag 'two words' plain",
+            27,
+            {
+                "runtime": "wasmer",
+                "module": Path("module.wasm"),
+                "preopen_dirs": [Path("src"), "path with space"],
+            },
+        )
+        is None
+    )
+
+    require_bin.assert_called_once_with("wasmer")
+    execute.assert_called_once_with(
+        [
+            "/opt/wasmer",
+            "run",
+            "--dir",
+            "src",
+            "--dir",
+            "path with space",
+            "module.wasm",
+            "--flag",
+            "two words",
+            "plain",
+        ],
+        27,
+    )
+
+
+def test_wasm_uses_default_runtime_directory_and_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    require_bin = MagicMock(return_value="wasmtime")
+    execute = MagicMock()
+    monkeypatch.setattr(sandbox_runner, "_require_bin", require_bin)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+
+    sandbox_runner._wasm_run("runner.wasm", None, 5, {})
+
+    require_bin.assert_called_once_with("wasmtime")
+    execute.assert_called_once_with(["wasmtime", "run", "--dir", ".", "runner.wasm"], 5)
+
+
+def test_wasm_reports_missing_module_after_runtime_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    require_bin = MagicMock(return_value="wasmtime")
+    execute = MagicMock()
+    monkeypatch.setattr(sandbox_runner, "_require_bin", require_bin)
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner._wasm_run("", None, 5, {})
+
+    assert raised.value.code == 2
+    assert capsys.readouterr() == ("", "WASM requires image or runtime_config.module\n")
+    require_bin.assert_called_once_with("wasmtime")
+    execute.assert_not_called()
+
+
+def test_wasm_preserves_command_parse_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    execute = MagicMock()
+    monkeypatch.setattr(sandbox_runner, "_require_bin", MagicMock(return_value="wasmtime"))
+    monkeypatch.setattr(sandbox_runner, "_run_subprocess", execute)
+
+    with pytest.raises(ValueError, match="No closing quotation"):
+        sandbox_runner._wasm_run("runner.wasm", "'unterminated", 5, {})
+
+    execute.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("runtime_type", "target", "expected_args"),
+    [
+        (
+            "docker",
+            "_docker_run",
+            ("sandbox", "image", "command", 12, {"KEY": "value"}, "bridge", {"cpu_count": 2}),
+        ),
+        ("lxc", "_lxc_run", ("sandbox", "image", "command", 12)),
+        ("firecracker", "_firecracker_run", ({"config_path": "config.json"}, 12)),
+        ("wasm", "_wasm_run", ("image", "command", 12, {"config_path": "config.json"})),
+    ],
+)
+def test_run_sandbox_dispatches_exact_runtime_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_type: str,
+    target: str,
+    expected_args: tuple,
+) -> None:
+    handlers = {
+        name: MagicMock(return_value=f"{name}-result")
+        for name in ("_docker_run", "_lxc_run", "_firecracker_run", "_wasm_run")
+    }
+    for name, handler in handlers.items():
+        monkeypatch.setattr(sandbox_runner, name, handler)
+
+    result = sandbox_runner.run_sandbox(
+        "sandbox",
+        "image",
+        "command",
+        12,
+        {"KEY": "value"},
+        runtime_type,
+        "bridge",
+        {"cpu_count": 2},
+        {"config_path": "config.json"},
+    )
+
+    assert result == f"{target}-result"
+    handlers[target].assert_called_once_with(*expected_args)
+    for name, handler in handlers.items():
+        if name != target:
+            handler.assert_not_called()
+
+
+def test_run_sandbox_normalizes_optional_configs_for_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    docker_run = MagicMock(return_value="done")
+    monkeypatch.setattr(sandbox_runner, "_docker_run", docker_run)
+
+    assert sandbox_runner.run_sandbox("id", "image", resource_limits=None, runtime_config=None) == "done"
+    docker_run.assert_called_once_with("id", "image", None, 300, None, "none", {})
+
+
+def test_run_sandbox_rejects_unsupported_runtime(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner.run_sandbox("id", "image", runtime_type="process")
+
+    assert raised.value.code == 2
+    assert capsys.readouterr() == ("", "Unsupported sandbox runtime_type: process\n")
+
+
+def test_main_parses_every_option_and_passes_environment_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_sandbox = MagicMock(return_value=None)
+    monkeypatch.setattr(sandbox_runner, "run_sandbox", run_sandbox)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "observal-sandbox-run",
+            "ignored",
+            "--sandbox-id",
+            "sandbox-id",
+            "--image",
+            "runner.wasm",
+            "--runtime-type",
+            "wasm",
+            "--command",
+            "old command",
+            "--timeout",
+            "41",
+            "--network-policy",
+            "restricted",
+            "--resource-limits",
+            '{"memory_mb": 256}',
+            "--runtime-config",
+            '{"module": "module.wasm"}',
+            "--env",
+            'TOKEN="first"',
+            "--env",
+            "PATH=/untrusted/bin",
+            "--env",
+            "NO_EQUALS",
+            "--env",
+            "TOKEN='last'",
+            "unknown-value",
+        ],
+    )
+
+    assert sandbox_runner.main() is None
+
+    run_sandbox.assert_called_once_with(
+        "sandbox-id",
+        "runner.wasm",
+        "old command",
+        41,
+        {"TOKEN": "last", "PATH": "/untrusted/bin", "NO_EQUALS": ""},
+        "wasm",
+        "restricted",
+        {"memory_mb": 256},
+        {"module": "module.wasm"},
+    )
+
+
+def test_main_command_delimiter_replaces_option_command_and_stops_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_sandbox = MagicMock(return_value=None)
+    monkeypatch.setattr(sandbox_runner, "run_sandbox", run_sandbox)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "observal-sandbox-run",
+            "--sandbox-id",
+            "id",
+            "--image",
+            "image",
+            "--command",
+            "old",
+            "--",
+            "echo",
+            "hello world",
+            "--timeout",
+            "1",
+        ],
+    )
+
+    sandbox_runner.main()
+
+    run_sandbox.assert_called_once_with(
+        "id", "image", "echo hello world --timeout 1", 300, {}, "docker", "none", {}, {}
+    )
+
+
+@pytest.mark.parametrize("runtime_type", ["docker", "lxc", "wasm"])
+def test_main_requires_image_for_image_based_runtimes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    runtime_type: str,
+) -> None:
+    run_sandbox = MagicMock()
+    monkeypatch.setattr(sandbox_runner, "run_sandbox", run_sandbox)
+    monkeypatch.setattr(sys, "argv", ["observal-sandbox-run", "--runtime-type", runtime_type])
+
+    with pytest.raises(SystemExit) as raised:
+        sandbox_runner.main()
+
+    assert raised.value.code == 1
+    assert capsys.readouterr() == (
+        "",
+        "Usage: observal-sandbox-run --sandbox-id <id> --image <image> "
+        "[--runtime-type docker|lxc|firecracker|wasm] [--command <cmd>] [--timeout <s>]\n",
+    )
+    run_sandbox.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("runtime_type", "runtime_config"),
+    [("firecracker", {}), ("wasm", {"module": "runner.wasm"})],
+)
+def test_main_allows_runtime_config_driven_execution_without_image(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_type: str,
+    runtime_config: dict,
+) -> None:
+    run_sandbox = MagicMock(return_value=None)
+    monkeypatch.setattr(sandbox_runner, "run_sandbox", run_sandbox)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "observal-sandbox-run",
+            "--sandbox-id",
+            "id",
+            "--runtime-type",
+            runtime_type,
+            "--runtime-config",
+            json.dumps(runtime_config),
+        ],
+    )
+
+    sandbox_runner.main()
+
+    run_sandbox.assert_called_once_with("id", "", None, 300, {}, runtime_type, "none", {}, runtime_config)
+
+
+@pytest.mark.parametrize(
+    ("option", "value", "error_type"),
+    [
+        ("--timeout", "never", ValueError),
+        ("--resource-limits", "{", json.JSONDecodeError),
+        ("--runtime-config", "{", json.JSONDecodeError),
+    ],
+)
+def test_main_preserves_numeric_and_json_parse_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    option: str,
+    value: str,
+    error_type: type[Exception],
+) -> None:
+    run_sandbox = MagicMock()
+    monkeypatch.setattr(sandbox_runner, "run_sandbox", run_sandbox)
+    monkeypatch.setattr(sys, "argv", ["observal-sandbox-run", "--image", "image", option, value])
+
+    with pytest.raises(error_type):
+        sandbox_runner.main()
+
+    run_sandbox.assert_not_called()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!--- Please fill the necessary details below -->
## Purpose / Description
This PR adds comprehensive, hermetic unit tests for the sandbox registry CLI commands (`submit`, `list`, `show`, `install`, `delete`) in `observal_cli/tests/test_cmd_sandbox.py`. Previously, these commands lacked structured test coverage, making it difficult to guarantee behavioral correctness and prevent regressions during future refactoring.

## Fixes
* Part of Improve test coverage for untested modules #898 

## Approach
The tests are structured strictly following the project's `Testing_Guide.md`:
* **Hermetic Execution**: Introduced a `sandbox_home` pytest fixture using `monkeypatch` to redirect `HOME`/`USERPROFILE` and the current working directory to a `tmp_path`. This ensures tests never read or write to the developer's real configuration.
* **Boundary Mocking**: Mocked external boundaries (`observal_cli.client`, `observal_cli.config.resolve_alias`, `observal_cli.cmd_sandbox.console.print`) rather than internal implementation details.
* **Behavioral Assertions**: Verified user-visible behavior (exit codes, output strings, and specific mock call arguments) using a clear arrange/act/assert flow with blank lines for readability.
* **Edge Cases**: Covered critical edge cases including missing files, invalid JSON, empty API results, missing payload fields, conflicting CLI flags, and unconfirmed deletions.
* **Type Safety & Linting**: Moved `pathlib.Path` into a `TYPE_CHECKING` block to satisfy `ruff` (TC003), added `-> None` return type hints to all test methods, and ensured `result.output` is included in all exit code assertions for easy debugging.

## How Has This Been Tested?

Run locally with:
```bash
cd observal-server
uv run pytest ../observal_cli/tests/test_cmd_sandbox.py -v
```

## Learning (optional, can help others)
This work followed the project's `Testing_Guide.md` conventions for hermetic, boundary-mocked unit tests.

Key patterns used:
* `monkeypatch` to redirect `HOME` / `USERPROFILE` and the CWD to a `tmp_path` fixture, so tests never touch real developer config — a common pytest pattern for CLI tools that read user config directories.
* Mocking at external boundaries (`client`, `config.resolve_alias`, `console.print`) instead of internal functions, to keep tests resilient to internal refactors while still catching behavioral regressions.
* Using `TYPE_CHECKING` for `pathlib.Path` imports to satisfy `ruff`'s `TC003` rule without incurring the import cost at runtime.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for sandbox registry CLI workflows, including command submission, validation, listing, editing, archiving, details lookup, and co-author management.
  * Added tests for draft and team targeting, file and JSON errors, lock handling, removed commands, and failure behavior.
  * Verified user-facing output and request payloads across supported workflows.
  * Added coverage for sandbox execution across supported runtimes, including configuration validation, environment handling, cleanup, interruptions, command parsing, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->