### PR TITLE
test:added unit test for ee/observal_insights/ modules

### DIFF
--- a/tests/test_insights_anonymize.py
+++ b/tests/test_insights_anonymize.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for version_impact.py — anonymized cross-user layer analysis.
+
+Covers: _median, _robust_outlier_labels, _confidence_for_groups,
+diff_snapshots, extract_content_summary, and build_version_impact_data
+(lightweight and significant paths).
+
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights anonymize/version_impact tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+def _group(layer_hash: str, sessions: int = 10, users: int = 2, success: float = 0.8, error_rate: float = 0.05) -> dict:
+    return {
+        "agent_version": "1.0.0",
+        "layer_hash": layer_hash,
+        "sessions": sessions,
+        "users": users,
+        "avg_prompts": 5.0,
+        "avg_tool_calls": 10.0,
+        "avg_duration_seconds": 300.0,
+        "avg_cost": 0.05,
+        "avg_tokens": 20000,
+        "tool_error_rate": error_rate,
+        "success_proxy": success,
+    }
+
+
+def _snapshot(is_canonical: bool = True, files: list | None = None) -> dict:
+    return {
+        "drift": {"is_canonical": is_canonical},
+        "harnesses": {
+            "claude-code": files
+            or [
+                {"path": "CLAUDE.md", "hash": "abc123", "content": "## Rules\nAlways show diffs."},
+            ]
+        },
+        "pinned_versions": {"scope-guard": "1.1.0"},
+    }
+
+
+class TestMedian:
+    def test_empty_returns_zero(self):
+        from services.insights.version_impact import _median
+
+        assert _median([]) == 0.0
+
+    def test_single_value(self):
+        from services.insights.version_impact import _median
+
+        assert _median([5.0]) == 5.0
+
+    def test_odd_count(self):
+        from services.insights.version_impact import _median
+
+        assert _median([1.0, 2.0, 3.0]) == 2.0
+
+    def test_even_count(self):
+        from services.insights.version_impact import _median
+
+        assert _median([1.0, 2.0, 3.0, 4.0]) == 2.5
+
+
+class TestRobustOutlierLabels:
+    def test_fewer_than_three_groups_all_normal(self):
+        from services.insights.version_impact import _robust_outlier_labels
+
+        groups = [_group("h1"), _group("h2")]
+        labels = _robust_outlier_labels(groups, "success_proxy")
+        assert all(v == "normal" for v in labels.values())
+
+    def test_positive_outlier_labeled(self):
+        from services.insights.version_impact import _robust_outlier_labels
+
+        # One group has dramatically higher success than the rest
+        groups = [
+            _group("low1", success=0.3),
+            _group("low2", success=0.3),
+            _group("low3", success=0.3),
+            _group("high", success=0.95),
+        ]
+        labels = _robust_outlier_labels(groups, "success_proxy")
+        assert labels["high"] == "positive_outlier"
+
+    def test_negative_outlier_labeled(self):
+        from services.insights.version_impact import _robust_outlier_labels
+
+        groups = [
+            _group("high1", success=0.9),
+            _group("high2", success=0.9),
+            _group("high3", success=0.9),
+            _group("low", success=0.1),
+        ]
+        labels = _robust_outlier_labels(groups, "success_proxy")
+        assert labels["low"] == "negative_outlier"
+
+    def test_similar_groups_all_normal(self):
+        from services.insights.version_impact import _robust_outlier_labels
+
+        groups = [_group(f"h{i}", success=0.8 + i * 0.01) for i in range(5)]
+        labels = _robust_outlier_labels(groups, "success_proxy")
+        assert all(v == "normal" for v in labels.values())
+
+
+class TestConfidenceForGroups:
+    def test_insufficient_data_too_few_sessions(self):
+        from services.insights.version_impact import _confidence_for_groups
+
+        groups = [_group("h1", sessions=3), _group("h2", sessions=4)]
+        assert _confidence_for_groups(groups, significant=True) == "insufficient_data"
+
+    def test_high_confidence_many_sessions_multi_user(self):
+        from services.insights.version_impact import _confidence_for_groups
+
+        groups = [
+            _group("h1", sessions=20, users=3),
+            _group("h2", sessions=15, users=2),
+        ]
+        assert _confidence_for_groups(groups, significant=True) == "high"
+
+    def test_low_confidence_when_not_significant(self):
+        from services.insights.version_impact import _confidence_for_groups
+
+        groups = [_group("h1", sessions=20, users=2), _group("h2", sessions=15, users=1)]
+        assert _confidence_for_groups(groups, significant=False) == "low"
+
+
+class TestDiffSnapshots:
+    def test_added_files_detected(self):
+        from services.insights.version_impact import diff_snapshots
+
+        snap_a = {"harnesses": {"cursor": []}}
+        snap_b = {"harnesses": {"cursor": [{"path": "rules.md", "hash": "x"}]}}
+        diff = diff_snapshots(snap_a, snap_b)
+        assert "cursor/rules.md" in diff["added"]
+
+    def test_removed_files_detected(self):
+        from services.insights.version_impact import diff_snapshots
+
+        snap_a = {"harnesses": {"cursor": [{"path": "rules.md", "hash": "x"}]}}
+        snap_b = {"harnesses": {"cursor": []}}
+        diff = diff_snapshots(snap_a, snap_b)
+        assert "cursor/rules.md" in diff["removed"]
+
+    def test_modified_files_detected(self):
+        from services.insights.version_impact import diff_snapshots
+
+        snap_a = {"harnesses": {"cursor": [{"path": "rules.md", "hash": "aaa"}]}}
+        snap_b = {"harnesses": {"cursor": [{"path": "rules.md", "hash": "bbb"}]}}
+        diff = diff_snapshots(snap_a, snap_b)
+        assert "cursor/rules.md" in diff["modified"]
+
+    def test_identical_snapshots_empty_diff(self):
+        from services.insights.version_impact import diff_snapshots
+
+        snap = {"harnesses": {"cursor": [{"path": "rules.md", "hash": "abc"}]}}
+        diff = diff_snapshots(snap, snap)
+        assert diff["added"] == []
+        assert diff["removed"] == []
+        assert diff["modified"] == []
+
+    def test_empty_snapshots(self):
+        from services.insights.version_impact import diff_snapshots
+
+        diff = diff_snapshots({}, {})
+        assert diff["added"] == []
+        assert diff["removed"] == []
+        assert diff["modified"] == []
+
+
+class TestExtractContentSummary:
+    def test_returns_behavioral_file_content(self):
+        from services.insights.version_impact import extract_content_summary
+
+        snap = {
+            "harnesses": {
+                "claude-code": [
+                    {"path": "CLAUDE.md", "hash": "x", "content": "## Rules\nAlways show diffs."},
+                ]
+            }
+        }
+        summary = extract_content_summary(snap)
+        assert "CLAUDE.md" in summary
+        assert "Always show diffs." in summary
+
+    def test_excludes_non_behavioral_files(self):
+        from services.insights.version_impact import extract_content_summary
+
+        snap = {
+            "harnesses": {
+                "claude-code": [
+                    {"path": "package.json", "hash": "x", "content": '{"name": "app"}'},
+                    {"path": "AGENTS.md", "hash": "y", "content": "agent rules here"},
+                ]
+            }
+        }
+        summary = extract_content_summary(snap)
+        assert "package.json" not in summary
+        assert "AGENTS.md" in summary
+
+    def test_truncates_long_content(self):
+        from services.insights.version_impact import extract_content_summary
+
+        snap = {
+            "harnesses": {
+                "claude-code": [
+                    {"path": "CLAUDE.md", "hash": "x", "content": "x" * 2000},
+                ]
+            }
+        }
+        summary = extract_content_summary(snap, max_chars=500)
+        assert len(summary) <= 1000  # generous bound, just ensure truncation
+
+    def test_empty_snapshot_returns_placeholder(self):
+        from services.insights.version_impact import extract_content_summary
+
+        assert extract_content_summary({}) == "(no behavioral content captured)"
+
+
+class TestBuildVersionImpactData:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_fewer_than_two_groups(self, monkeypatch):
+        from services.insights import version_impact
+
+        monkeypatch.setattr(version_impact, "detect_layer_groups", AsyncMock(return_value=[_group("h1")]))
+
+        result = await version_impact.build_version_impact_data(
+            agent_id="a1", period_start="2026-01-01", period_end="2026-01-31"
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_lightweight_summary_when_no_significant_gap(self, monkeypatch):
+        from services.insights import version_impact
+
+        # Two groups with similar success rates — no significant gap
+        groups = [_group("h1", success=0.81), _group("h2", success=0.80)]
+        monkeypatch.setattr(version_impact, "detect_layer_groups", AsyncMock(return_value=groups))
+
+        result = await version_impact.build_version_impact_data(
+            agent_id="a1", period_start="2026-01-01", period_end="2026-01-31"
+        )
+        assert result is not None
+        assert result["significant"] is False
+        assert "finding" in result
+
+    @pytest.mark.asyncio
+    async def test_fetches_snapshots_for_significant_gap(self, monkeypatch):
+        from services.insights import version_impact
+
+        # Significant success gap: 0.9 vs 0.3 → 60% gap
+        groups = [_group("h1", success=0.9, sessions=20, users=3), _group("h2", success=0.3, sessions=20, users=3)]
+        monkeypatch.setattr(version_impact, "detect_layer_groups", AsyncMock(return_value=groups))
+
+        snapshots = {"h1": _snapshot(is_canonical=True), "h2": _snapshot(is_canonical=False)}
+        fetch_mock = AsyncMock(return_value=snapshots)
+        monkeypatch.setattr(version_impact, "fetch_layer_snapshots_for_groups", fetch_mock)
+
+        result = await version_impact.build_version_impact_data(
+            agent_id="a1", period_start="2026-01-01", period_end="2026-01-31"
+        )
+        fetch_mock.assert_called_once()
+        assert result is not None
+        assert result["significant"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_snapshots_insufficient(self, monkeypatch):
+        from services.insights import version_impact
+
+        groups = [_group("h1", success=0.9, sessions=20, users=3), _group("h2", success=0.3, sessions=20, users=3)]
+        monkeypatch.setattr(version_impact, "detect_layer_groups", AsyncMock(return_value=groups))
+        # Only one snapshot returned → can't compare best vs worst
+        monkeypatch.setattr(
+            version_impact, "fetch_layer_snapshots_for_groups", AsyncMock(return_value={"h1": _snapshot()})
+        )
+
+        result = await version_impact.build_version_impact_data(
+            agent_id="a1", period_start="2026-01-01", period_end="2026-01-31"
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_canonical_dirty_counts_populated(self, monkeypatch):
+        from services.insights import version_impact
+
+        groups = [
+            _group("canon", success=0.9, sessions=15, users=3),
+            _group("dirty", success=0.4, sessions=15, users=3),
+        ]
+        monkeypatch.setattr(version_impact, "detect_layer_groups", AsyncMock(return_value=groups))
+        snapshots = {
+            "canon": _snapshot(is_canonical=True),
+            "dirty": _snapshot(is_canonical=False),
+        }
+        monkeypatch.setattr(version_impact, "fetch_layer_snapshots_for_groups", AsyncMock(return_value=snapshots))
+
+        result = await version_impact.build_version_impact_data(
+            agent_id="a1", period_start="2026-01-01", period_end="2026-01-31"
+        )
+        assert result is not None
+        canon_dirty = result["canonical_dirty_summary"]
+        assert canon_dirty["canonical_sessions"] == 15
+        assert canon_dirty["dirty_sessions"] == 15

--- a/tests/test_insights_enrichment.py
+++ b/tests/test_insights_enrichment.py
@@ -1,0 +1,348 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for session_meta_extractor — deterministic per-session enrichment."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights enrichment tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+def _raw(entry: dict) -> str:
+    return json.dumps(entry)
+
+
+def _assistant_msg(tool_name: str, args: dict, model: str = "claude-haiku", tool_id: str | None = None) -> str:
+    return _raw(
+        {
+            "type": "message",
+            "timestamp": "2026-01-01T10:00:00Z",
+            "message": {
+                "role": "assistant",
+                "model": model,
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "name": tool_name,
+                        "id": tool_id or f"t_{tool_name}",
+                        "arguments": args,
+                    }
+                ],
+                "usage": {
+                    "input": 1000,
+                    "output": 200,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                    "cost": {"total": 0.01},
+                },
+            },
+        }
+    )
+
+
+def _user_msg(text: str, ts: str = "2026-01-01T10:00:00Z") -> str:
+    return _raw(
+        {
+            "type": "message",
+            "timestamp": ts,
+            "message": {
+                "role": "user",
+                "content": text,
+            },
+        }
+    )
+
+
+def _tool_result(tool_name: str, is_error: bool, content: str) -> str:
+    return _raw(
+        {
+            "type": "message",
+            "timestamp": "2026-01-01T10:01:00Z",
+            "message": {
+                "role": "toolResult",
+                "toolName": tool_name,
+                "isError": is_error,
+                "content": content,
+            },
+        }
+    )
+
+
+def _session_header(cwd: str = "/repo/app") -> str:
+    return _raw({"type": "session", "timestamp": "2026-01-01T10:00:00Z", "cwd": cwd})
+
+
+class TestExtractSessionMeta:
+    def test_empty_lines_returns_zero_stats(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        meta = extract_session_meta("s1", [])
+        assert meta["session_id"] == "s1"
+        assert meta["total_messages"] == 0
+        assert meta["tool_errors"] == 0
+
+    def test_user_message_count(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_user_msg("hello"), _user_msg("thanks")]
+        meta = extract_session_meta("s1", lines)
+        assert meta["user_message_count"] == 2
+
+    def test_tool_call_counted(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_msg("bash", {"command": "ls -la"})]
+        meta = extract_session_meta("s1", lines)
+        assert meta["tool_counts"].get("bash", 0) == 1
+
+    def test_tool_call_deduplication_by_id(self):
+        """Same tool_id appearing twice must be counted once."""
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        line = _assistant_msg("bash", {"command": "echo hi"}, tool_id="dup-id")
+        meta = extract_session_meta("s1", [line, line])
+        assert meta["tool_counts"].get("bash", 0) == 1
+
+    def test_git_commit_detection(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_msg("bash", {"command": "git commit -m 'fix: test'"})]
+        meta = extract_session_meta("s1", lines)
+        assert meta["git_commits"] == 1
+
+    def test_git_push_detection(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_msg("bash", {"command": "git push origin main"})]
+        meta = extract_session_meta("s1", lines)
+        assert meta["git_pushes"] == 1
+
+    def test_tool_error_counted(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_tool_result("bash", True, "command failed with exit code 1")]
+        meta = extract_session_meta("s1", lines)
+        assert meta["tool_errors"] == 1
+
+    def test_tool_error_category_command_failed(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_tool_result("bash", True, "command failed with exit code 1")]
+        meta = extract_session_meta("s1", lines)
+        assert meta["tool_error_categories"].get("command_failed", 0) == 1
+
+    def test_tool_error_category_file_not_found(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_tool_result("read", True, "no such file or directory")]
+        meta = extract_session_meta("s1", lines)
+        assert meta["tool_error_categories"].get("file_not_found", 0) == 1
+
+    def test_interruption_detected(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_user_msg("[Request interrupted by user for new prompt]")]
+        meta = extract_session_meta("s1", lines)
+        assert meta["user_interruptions"] == 1
+
+    def test_subagent_detection(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_msg("subagent", {})]
+        meta = extract_session_meta("s1", lines)
+        assert meta["uses_subagent"] is True
+
+    def test_mcp_tool_detection(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_msg("mcp__github__get_pr", {})]
+        meta = extract_session_meta("s1", lines)
+        assert meta["uses_mcp"] is True
+
+    def test_language_detected_from_write_path(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_msg("write", {"path": "/repo/app/main.py", "content": "print('hi')\n"})]
+        meta = extract_session_meta("s1", lines)
+        assert "Python" in meta["languages"]
+
+    def test_language_detected_from_edit_path(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [
+            _assistant_msg(
+                "edit",
+                {
+                    "path": "/repo/app/index.ts",
+                    "edits": [{"oldText": "old\n", "newText": "new\n"}],
+                },
+            )
+        ]
+        meta = extract_session_meta("s1", lines)
+        assert "TypeScript" in meta["languages"]
+
+    def test_lines_added_from_write(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        content = "line1\nline2\nline3"
+        lines = [_assistant_msg("write", {"path": "/a.py", "content": content})]
+        meta = extract_session_meta("s1", lines)
+        assert meta["lines_added"] == 3  # 2 newlines + 1
+
+    def test_project_path_from_session_header(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_session_header("/home/user/myproject")]
+        meta = extract_session_meta("s1", lines)
+        assert meta["project_path"] == "/home/user/myproject"
+
+    def test_duration_computed_from_timestamps(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        line1 = _raw(
+            {
+                "type": "message",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "message": {"role": "user", "content": "start"},
+            }
+        )
+        line2 = _raw(
+            {
+                "type": "message",
+                "timestamp": "2026-01-01T10:10:00Z",
+                "message": {"role": "user", "content": "end"},
+            }
+        )
+        meta = extract_session_meta("s1", [line1, line2])
+        assert meta["duration_seconds"] == pytest.approx(600.0)
+
+    def test_invalid_json_lines_are_skipped(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        # Only lines that raise JSONDecodeError are skipped; "null" parses to None
+        # and is also handled. Use truly broken JSON and empty lines.
+        meta = extract_session_meta("s1", ["{broken json", "", "   "])
+        assert meta["total_messages"] == 0
+
+    def test_model_usage_aggregated(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_msg("bash", {}, model="claude-haiku-20250514")]
+        meta = extract_session_meta("s1", lines)
+        assert "claude-haiku-20250514" in meta["model_usage"]
+        assert meta["model_usage"]["claude-haiku-20250514"]["input_tokens"] == 1000
+
+
+class TestAggregateMetas:
+    def _make_meta(
+        self,
+        session_id: str = "s1",
+        cost: float = 0.05,
+        input_tokens: int = 1000,
+        output_tokens: int = 200,
+        duration: float = 300.0,
+        tool_counts: dict | None = None,
+    ) -> dict:
+        return {
+            "session_id": session_id,
+            "total_messages": 5,
+            "duration_seconds": duration,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "total_cost": cost,
+            "credits": 0.0,
+            "lines_added": 10,
+            "lines_removed": 5,
+            "files_modified": 2,
+            "git_commits": 1,
+            "git_pushes": 0,
+            "tool_errors": 0,
+            "user_interruptions": 0,
+            "uses_subagent": False,
+            "uses_mcp": False,
+            "tool_counts": tool_counts or {"bash": 3},
+            "languages": {"Python": 2},
+            "tool_error_categories": {},
+            "model_usage": {
+                "claude-haiku": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cost": cost,
+                    "messages": 5,
+                }
+            },
+            "project_path": "/repo/app",
+            "user_response_times": [10.0, 20.0],
+            "message_hours": [10, 11],
+            "start_time": "2026-01-01T10:00:00Z",
+            "harness": "claude-code",
+            "user_message_count": 3,
+            "user_message_timestamps": [],
+            "layer_hash": "",
+            "agent_version": "",
+        }
+
+    def test_aggregates_totals(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        metas = [self._make_meta("s1", cost=0.1), self._make_meta("s2", cost=0.2)]
+        agg = aggregate_metas(metas)
+        assert agg["total_sessions"] == 2
+        assert agg["total_cost"] == pytest.approx(0.3)
+        assert agg["total_messages"] == 10
+
+    def test_aggregates_tool_counts(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        metas = [
+            self._make_meta("s1", tool_counts={"bash": 3, "edit": 2}),
+            self._make_meta("s2", tool_counts={"bash": 5}),
+        ]
+        agg = aggregate_metas(metas)
+        assert agg["tool_counts"]["bash"] == 8
+        assert agg["tool_counts"]["edit"] == 2
+
+    def test_top_tools_sorted_by_frequency(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        metas = [self._make_meta(tool_counts={"read": 1, "bash": 10, "edit": 3})]
+        agg = aggregate_metas(metas)
+        top_names = [t[0] for t in agg["top_tools"]]
+        assert top_names[0] == "bash"
+
+    def test_days_active_counted(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        m1 = self._make_meta("s1")
+        m1["start_time"] = "2026-01-01T10:00:00Z"
+        m2 = self._make_meta("s2")
+        m2["start_time"] = "2026-01-02T10:00:00Z"
+        agg = aggregate_metas([m1, m2])
+        assert agg["days_active"] == 2
+
+    def test_empty_metas_returns_zero_sessions(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        agg = aggregate_metas([])
+        assert agg["total_sessions"] == 0
+
+    def test_model_tier_subscription_detected(self):
+        """Model with high token usage but near-zero cost gets 'subscription' tier."""
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        meta = self._make_meta(input_tokens=100_000, output_tokens=20_000, cost=0.0)
+        meta["model_usage"] = {
+            "claude-sub": {"input_tokens": 100_000, "output_tokens": 20_000, "cost": 0.0, "messages": 50}
+        }
+        agg = aggregate_metas([meta])
+        assert agg.get("model_tiers", {}).get("claude-sub") == "subscription"

--- a/tests/test_insights_facets.py
+++ b/tests/test_insights_facets.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for facets.py — per-session LLM facet extraction and aggregation."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights facets tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+def _full_facet(
+    goal: str = "fix_bug",
+    outcome: str = "fully_achieved",
+    satisfaction: str = "satisfied",
+    helpfulness: str = "very_helpful",
+    session_type: str = "single_task",
+    complexity: str = "low",
+) -> dict:
+    return {
+        "underlying_goal": "fix the login bug",
+        "goal_categories": [goal],
+        "outcome": outcome,
+        "user_satisfaction": satisfaction,
+        "agent_helpfulness": helpfulness,
+        "session_type": session_type,
+        "complexity": complexity,
+        "friction_points": [],
+        "primary_success_factors": ["correct_code_edits"],
+        "tools_effective": ["bash", "edit"],
+        "tools_problematic": [],
+        "repeated_instructions": [],
+        "brief_summary": "User wanted to fix a bug; agent did it.",
+    }
+
+
+class TestExtractFacets:
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_short_transcript(self, monkeypatch):
+        from services.insights import facets
+
+        call_mock = AsyncMock()
+        monkeypatch.setattr(facets, "get_call_model", lambda: call_mock)
+
+        import services.dynamic_settings as ds
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        result = await facets.extract_facets("s1", "hi", {})
+        assert result == {}
+        call_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_blank_transcript(self, monkeypatch):
+        from services.insights import facets
+
+        call_mock = AsyncMock()
+        monkeypatch.setattr(facets, "get_call_model", lambda: call_mock)
+
+        import services.dynamic_settings as ds
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        result = await facets.extract_facets("s1", "   ", {})
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_calls_model_with_long_transcript(self, monkeypatch):
+        from services.insights import facets
+
+        expected = _full_facet()
+        call_mock = AsyncMock(return_value=expected)
+        monkeypatch.setattr(facets, "get_call_model", lambda: call_mock)
+
+        import services.dynamic_settings as ds
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        transcript = "x" * 200
+        result = await facets.extract_facets("s1", transcript, {})
+        assert result == expected
+        call_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_model_exception_returns_empty(self, monkeypatch):
+        from services.insights import facets
+
+        call_mock = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+        monkeypatch.setattr(facets, "get_call_model", lambda: call_mock)
+
+        import services.dynamic_settings as ds
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        result = await facets.extract_facets("s1", "x" * 200, {})
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_model_non_dict_response_returns_empty(self, monkeypatch):
+        from services.insights import facets
+
+        call_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr(facets, "get_call_model", lambda: call_mock)
+
+        import services.dynamic_settings as ds
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        result = await facets.extract_facets("s1", "x" * 200, {})
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_uses_model_override_from_settings(self, monkeypatch):
+        from services.insights import facets
+
+        call_mock = AsyncMock(return_value=_full_facet())
+        monkeypatch.setattr(facets, "get_call_model", lambda: call_mock)
+
+        import services.dynamic_settings as ds
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value="claude-opus-4"))
+
+        await facets.extract_facets("s1", "x" * 200, {})
+        _, kwargs = call_mock.call_args
+        assert kwargs.get("model_override") == "claude-opus-4"
+
+
+class TestAggregateFacets:
+    def test_empty_returns_empty_dict(self):
+        from services.insights.facets import aggregate_facets
+
+        assert aggregate_facets([]) == {}
+
+    def test_counts_sessions(self):
+        from services.insights.facets import aggregate_facets
+
+        result = aggregate_facets([_full_facet(), _full_facet()])
+        assert result["sessions_with_facets"] == 2
+
+    def test_goal_categories_sorted_by_count(self):
+        from services.insights.facets import aggregate_facets
+
+        facets_list = [
+            _full_facet(goal="fix_bug"),
+            _full_facet(goal="fix_bug"),
+            _full_facet(goal="implement_feature"),
+        ]
+        result = aggregate_facets(facets_list)
+        top = result["goal_categories"][0]
+        assert top == ("fix_bug", 2)
+
+    def test_outcomes_counted(self):
+        from services.insights.facets import aggregate_facets
+
+        facets_list = [_full_facet(outcome="fully_achieved"), _full_facet(outcome="not_achieved")]
+        result = aggregate_facets(facets_list)
+        assert result["outcomes"]["fully_achieved"] == 1
+        assert result["outcomes"]["not_achieved"] == 1
+
+    def test_satisfaction_counted(self):
+        from services.insights.facets import aggregate_facets
+
+        result = aggregate_facets([_full_facet(satisfaction="happy")])
+        assert result["satisfaction"]["happy"] == 1
+
+    def test_friction_types_counted(self):
+        from services.insights.facets import aggregate_facets
+
+        f = _full_facet()
+        f["friction_points"] = [
+            {"type": "wrong_approach", "description": "went off rails", "severity": "major"},
+            {"type": "wrong_approach", "description": "again", "severity": "minor"},
+            {"type": "buggy_code", "description": "broken", "severity": "blocking"},
+        ]
+        result = aggregate_facets([f])
+        friction_map = dict(result["friction_types"])
+        assert friction_map["wrong_approach"] == 2
+        assert friction_map["buggy_code"] == 1
+
+    def test_tools_effective_aggregated(self):
+        from services.insights.facets import aggregate_facets
+
+        f1 = _full_facet()
+        f1["tools_effective"] = ["bash", "edit"]
+        f2 = _full_facet()
+        f2["tools_effective"] = ["bash"]
+        result = aggregate_facets([f1, f2])
+        tool_map = dict(result["tools_effective"])
+        assert tool_map["bash"] == 2
+        assert tool_map["edit"] == 1
+
+    def test_tools_problematic_with_dict_format(self):
+        from services.insights.facets import aggregate_facets
+
+        f = _full_facet()
+        f["tools_problematic"] = [{"tool": "bash", "reason": "timeout"}]
+        result = aggregate_facets([f])
+        tool_map = dict(result["tools_problematic"])
+        assert tool_map["bash"] == 1
+
+    def test_repeated_instructions_deduplicated_by_frequency(self):
+        from services.insights.facets import aggregate_facets
+
+        instr = "always show diffs before editing"
+        f1 = _full_facet()
+        f1["repeated_instructions"] = [instr]
+        f2 = _full_facet()
+        f2["repeated_instructions"] = [instr]
+        f3 = _full_facet()
+        f3["repeated_instructions"] = ["other instruction appearing once"]
+        result = aggregate_facets([f1, f2, f3])
+        # Only instructions with frequency >= 2 appear in repeated_summary
+        summaries = [r["instruction"] for r in result["repeated_instructions"]]
+        assert instr.lower() in summaries
+
+    def test_instructions_with_frequency_one_excluded(self):
+        from services.insights.facets import aggregate_facets
+
+        f = _full_facet()
+        f["repeated_instructions"] = ["unique instruction only once"]
+        result = aggregate_facets([f])
+        assert result["repeated_instructions"] == []
+
+    def test_skips_empty_facet_dicts(self):
+        from services.insights.facets import aggregate_facets
+
+        result = aggregate_facets([{}, _full_facet()])
+        # Empty facets are skipped; should still count the non-empty one
+        assert result["sessions_with_facets"] == 2  # len(all_facets) counts all including {}
+        # But outcomes etc. should only include data from the non-empty one
+        assert result["outcomes"].get("fully_achieved") == 1
+
+
+class TestLoadCachedFacetsBatch:
+    @pytest.mark.asyncio
+    async def test_empty_session_ids_returns_empty(self):
+        from services.insights.facets import load_cached_facets_batch
+
+        result = await load_cached_facets_batch([], MagicMock())
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_facets_keyed_by_session_id(self, monkeypatch):
+        from services.insights import facets
+
+        fake_row = MagicMock()
+        fake_row.session_id = "s1"
+        fake_row.facets = {"outcome": "fully_achieved"}
+
+        mock_model = MagicMock()
+        monkeypatch.setattr(facets, "get_facets_model", lambda: mock_model)
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [fake_row]
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        # Patch sqlalchemy.select at import-time location to bypass SA coercion
+        with patch("sqlalchemy.select", return_value=MagicMock(where=MagicMock(return_value=MagicMock()))):
+            result = await facets.load_cached_facets_batch(["s1"], mock_db)
+        assert "s1" in result
+        assert result["s1"]["outcome"] == "fully_achieved"
+
+    @pytest.mark.asyncio
+    async def test_rows_with_none_facets_excluded(self, monkeypatch):
+        from services.insights import facets
+
+        fake_row = MagicMock()
+        fake_row.session_id = "s1"
+        fake_row.facets = None
+
+        mock_model = MagicMock()
+        monkeypatch.setattr(facets, "get_facets_model", lambda: mock_model)
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [fake_row]
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch("sqlalchemy.select", return_value=MagicMock(where=MagicMock(return_value=MagicMock()))):
+            result = await facets.load_cached_facets_batch(["s1"], mock_db)
+        assert result == {}

--- a/tests/test_insights_html_export.py
+++ b/tests/test_insights_html_export.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for html_export.py — self-contained HTML report rendering."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights html_export tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+def _minimal_report(**overrides) -> dict:
+    base = {
+        "id": "rpt-001",
+        "agent_id": "agent-123",
+        "agent_name": "My Agent",
+        "status": "completed",
+        "period_start": "2026-01-01",
+        "period_end": "2026-01-31",
+        "sessions_analyzed": 10,
+        "metrics": {},
+        "narrative": {},
+        "facets_summary": {},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestHelperFunctions:
+    def test_esc_escapes_html_entities(self):
+        from services.insights.html_export import _esc
+
+        assert _esc("<script>alert('xss')</script>") == "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;"
+
+    def test_esc_none_returns_empty(self):
+        from services.insights.html_export import _esc
+
+        assert _esc(None) == ""
+
+    def test_format_cost_none_returns_zero(self):
+        from services.insights.html_export import _format_cost
+
+        assert _format_cost(None) == "$0.00"
+
+    def test_format_cost_small_value(self):
+        from services.insights.html_export import _format_cost
+
+        assert _format_cost(0.0023) == "$0.0023"
+
+    def test_format_cost_normal_value(self):
+        from services.insights.html_export import _format_cost
+
+        assert _format_cost(3.5) == "$3.50"
+
+    def test_format_number_none(self):
+        from services.insights.html_export import _format_number
+
+        assert _format_number(None) == "0"
+
+    def test_format_number_large_int(self):
+        from services.insights.html_export import _format_number
+
+        assert _format_number(1_234_567) == "1,234,567"
+
+    def test_format_number_float_whole(self):
+        from services.insights.html_export import _format_number
+
+        assert _format_number(5.0) == "5"
+
+    def test_format_number_float_fraction(self):
+        from services.insights.html_export import _format_number
+
+        assert _format_number(5.5) == "5.5"
+
+    def test_format_duration_zero(self):
+        from services.insights.html_export import _format_duration_hours
+
+        assert _format_duration_hours(0) == "0h"
+
+    def test_format_duration_minutes(self):
+        from services.insights.html_export import _format_duration_hours
+
+        assert _format_duration_hours(1800) == "30m"
+
+    def test_format_duration_hours(self):
+        from services.insights.html_export import _format_duration_hours
+
+        assert _format_duration_hours(7200) == "2.0h"
+
+    def test_severity_color_high(self):
+        from services.insights.html_export import _severity_color
+
+        assert _severity_color("high") == "#dc2626"
+
+    def test_severity_color_unknown(self):
+        from services.insights.html_export import _severity_color
+
+        # Unknown severity returns gray
+        assert _severity_color("critical") == "#6b7280"
+
+    def test_priority_color_low(self):
+        from services.insights.html_export import _priority_color
+
+        assert _priority_color("low") == "#16a34a"
+
+    def test_health_badge_healthy_contains_green(self):
+        from services.insights.html_export import _health_badge
+
+        badge = _health_badge("healthy")
+        assert "#16a34a" in badge
+        assert "HEALTHY" in badge
+
+    def test_health_badge_concerning_contains_red(self):
+        from services.insights.html_export import _health_badge
+
+        badge = _health_badge("concerning")
+        assert "#dc2626" in badge
+
+    def test_render_bar_chart_empty_returns_empty(self):
+        from services.insights.html_export import _render_bar_chart
+
+        assert _render_bar_chart([]) == ""
+
+    def test_render_bar_chart_produces_html(self):
+        from services.insights.html_export import _render_bar_chart
+
+        html = _render_bar_chart([("bash", 10), ("edit", 5)])
+        assert "bash" in html
+        assert "chart-bar" in html
+
+    def test_render_count_bar_chart_scales_to_max(self):
+        from services.insights.html_export import _render_count_bar_chart
+
+        html = _render_count_bar_chart([("a", 100), ("b", 50)])
+        # 'a' should have width 100%, 'b' should have width 50%
+        assert "100.0%" in html
+        assert "50.0%" in html
+
+    def test_render_pct_bar_chart_uses_values_as_pct(self):
+        from services.insights.html_export import _render_pct_bar_chart
+
+        html = _render_pct_bar_chart([("TypeScript", 75.0)])
+        assert "75.0%" in html
+
+
+class TestRenderReportHtml:
+    def test_returns_html_string(self):
+        from services.insights.html_export import render_report_html
+
+        html = render_report_html(_minimal_report())
+        assert isinstance(html, str)
+        assert html.startswith("<!DOCTYPE html>") or html.startswith("<!")
+
+    def test_contains_agent_name(self):
+        from services.insights.html_export import render_report_html
+
+        html = render_report_html(_minimal_report(agent_name="SuperAgent"))
+        assert "SuperAgent" in html
+
+    def test_contains_period_dates(self):
+        from services.insights.html_export import render_report_html
+
+        html = render_report_html(_minimal_report())
+        assert "2026-01-01" in html
+        assert "2026-01-31" in html
+
+    def test_handles_iso_datetime_period_start(self):
+        from services.insights.html_export import render_report_html
+
+        html = render_report_html(_minimal_report(period_start="2026-01-01T00:00:00Z"))
+        assert "2026-01-01" in html
+
+    def test_at_a_glance_section_rendered(self):
+        from services.insights.html_export import render_report_html
+
+        report = _minimal_report(
+            narrative={
+                "at_a_glance": {
+                    "health": "healthy",
+                    "whats_working": "bash usage is excellent",
+                    "whats_hindering": "some tool errors",
+                    "quick_win": "add a scope guard hook",
+                    "ambitious_workflows": "parallel subagents",
+                }
+            }
+        )
+        html = render_report_html(report)
+        assert "bash usage is excellent" in html
+        assert "scope guard hook" in html
+        assert "HEALTHY" in html
+
+    def test_xss_in_agent_name_is_escaped(self):
+        from services.insights.html_export import render_report_html
+
+        html = render_report_html(_minimal_report(agent_name="<script>alert(1)</script>"))
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_goal_categories_chart_rendered(self):
+        from services.insights.html_export import render_report_html
+
+        report = _minimal_report(
+            facets_summary={
+                "goal_categories": [("fix_bug", 10), ("implement_feature", 5)],
+            }
+        )
+        html = render_report_html(report)
+        assert "fix_bug" in html
+        assert "Goal Categories" in html
+
+    def test_friction_section_rendered(self):
+        from services.insights.html_export import render_report_html
+
+        report = _minimal_report(
+            narrative={
+                "friction_analysis": {
+                    "intro": "You have persistent friction.",
+                    "categories": [
+                        {
+                            "title": "Wrong Approach",
+                            "severity": "high",
+                            "description": "Agent went off-track",
+                            "examples": ["example 1"],
+                            "evidence": "3 out of 10 sessions",
+                            "impact": "wasted 2 hours",
+                        }
+                    ],
+                }
+            }
+        )
+        html = render_report_html(report)
+        assert "persistent friction" in html
+        assert "Wrong Approach" in html
+
+    def test_suggestions_rendered(self):
+        from services.insights.html_export import render_report_html
+
+        report = _minimal_report(
+            narrative={
+                "suggestions": {
+                    "config_additions": [
+                        {
+                            "action_type": "modify_prompt",
+                            "addition": "Always show diffs before editing",
+                            "why": "User repeatedly asks for this",
+                            "where": "system_prompt",
+                            "confidence": "high",
+                            "risk": "low",
+                        }
+                    ],
+                    "features_to_try": [],
+                    "usage_patterns": [],
+                }
+            }
+        )
+        html = render_report_html(report)
+        assert "Always show diffs before editing" in html
+
+    def test_rich_metrics_rendered_in_stats_row(self):
+        from services.insights.html_export import render_report_html
+
+        report = _minimal_report(
+            metrics={
+                "rich": {
+                    "total_messages": 500,
+                    "git_commits": 42,
+                    "lines_added": 10_000,
+                    "active_hours": 8.5,
+                    "days_active": 15,
+                }
+            }
+        )
+        html = render_report_html(report)
+        assert "500" in html
+        assert "42" in html
+
+    def test_empty_narrative_renders_without_crash(self):
+        from services.insights.html_export import render_report_html
+
+        # Should not raise even with completely empty data
+        html = render_report_html(_minimal_report())
+        assert len(html) > 100
+
+    def test_fun_ending_rendered_when_present(self):
+        from services.insights.html_export import render_report_html
+
+        report = _minimal_report(
+            narrative={
+                "fun_ending": {
+                    "headline": "You accidentally fixed two bugs at once",
+                    "detail": "Session 42 was a surprise",
+                }
+            }
+        )
+        html = render_report_html(report)
+        assert "accidentally fixed two bugs" in html

--- a/tests/test_insights_narrative.py
+++ b/tests/test_insights_narrative.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sections.py — parallel narrative section prompt execution.
+
+Covers: _call_section, generate_sections, section model routing, and
+synthesis prompt construction.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights narrative/sections tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+class TestCallSection:
+    @pytest.mark.asyncio
+    async def test_returns_section_name_and_result_on_success(self, monkeypatch):
+        from services.insights import sections
+
+        call_mock = AsyncMock(return_value={"what_works": {"intro": "it works", "strengths": []}})
+        monkeypatch.setattr(sections, "get_call_model", lambda: call_mock)
+
+        name, result = await sections._call_section("what_works", "prompt text")
+        assert name == "what_works"
+        assert result["what_works"]["intro"] == "it works"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_on_exception(self, monkeypatch):
+        from services.insights import sections
+
+        call_mock = AsyncMock(side_effect=Exception("network error"))
+        monkeypatch.setattr(sections, "get_call_model", lambda: call_mock)
+
+        name, result = await sections._call_section("what_works", "prompt")
+        assert name == "what_works"
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_propagates_runtime_error(self, monkeypatch):
+        from services.insights import sections
+
+        call_mock = AsyncMock(side_effect=RuntimeError("not configured"))
+        monkeypatch.setattr(sections, "get_call_model", lambda: call_mock)
+
+        with pytest.raises(RuntimeError):
+            await sections._call_section("what_works", "prompt")
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_when_model_returns_none(self, monkeypatch):
+        from services.insights import sections
+
+        call_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr(sections, "get_call_model", lambda: call_mock)
+
+        name, result = await sections._call_section("fun_ending", "prompt")
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_uses_section_max_tokens_override(self, monkeypatch):
+        from services.insights import sections
+
+        calls: list[dict] = []
+
+        async def call_model(prompt, **kwargs):
+            calls.append(kwargs)
+            return {"fun_ending": {"headline": "x", "detail": "y"}}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: call_model)
+
+        await sections._call_section("fun_ending", "prompt")
+        assert calls[0]["max_tokens"] == 1024  # fun_ending override
+
+
+class TestGenerateSections:
+    def _make_call_mock(self, responses: dict | None = None) -> AsyncMock:
+        """Return a call_model mock that returns canned responses per first-word lookup."""
+        defaults = {
+            "what_they_work_on": {"what_they_work_on": {"areas": []}},
+            "interaction_style": {"interaction_style": {"narrative": "", "key_pattern": ""}},
+            "usage_patterns": {"usage_patterns": {"narrative": "", "top_tasks": []}},
+            "what_works": {"what_works": {"intro": "", "strengths": []}},
+            "friction_analysis": {"friction_analysis": {"intro": "", "categories": []}},
+            "suggestions": {"suggestions": {"config_additions": [], "features_to_try": [], "usage_patterns": []}},
+            "usage_cost_analysis": {"usage_cost_analysis": {"summary": "", "metrics": {}}},
+            "version_comparison": {"version_comparison": {"has_comparison": False}},
+            "regression_detection": {"regression_detection": {"has_previous_data": False}},
+            "on_the_horizon": {"on_the_horizon": {"intro": "", "opportunities": []}},
+            "fun_ending": {"fun_ending": {"headline": "test", "detail": "test detail"}},
+            "version_impact": {"version_impact": {"summary": ""}},
+            "at_a_glance": {
+                "at_a_glance": {
+                    "health": "mixed",
+                    "whats_working": "",
+                    "whats_hindering": "",
+                    "quick_win": "",
+                    "ambitious_workflows": "",
+                }
+            },
+        }
+        if responses:
+            defaults.update(responses)
+
+        # The call_model is invoked many times; return canned by checking prompt content
+        async def _call(prompt: str, **kwargs) -> dict:
+            for key, resp in defaults.items():
+                if key in prompt or (key == "at_a_glance" and "At a Glance" in prompt):
+                    return resp
+            return {"at_a_glance": defaults["at_a_glance"]["at_a_glance"]}
+
+        return _call
+
+    @pytest.mark.asyncio
+    async def test_generate_sections_returns_all_section_keys(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+        monkeypatch.setattr(sections, "get_call_model", lambda: self._make_call_mock())
+
+        result = await sections.generate_sections(data_block='{"total_sessions": 5}')
+
+        # Core narrative sections must be present
+        for key in ("what_works", "friction_analysis", "suggestions", "at_a_glance"):
+            assert key in result, f"Missing section: {key}"
+
+    @pytest.mark.asyncio
+    async def test_previous_data_block_included_for_regression(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        prompts_seen: list[str] = []
+
+        async def recording_model(prompt: str, **kwargs) -> dict:
+            prompts_seen.append(prompt)
+            return {
+                "at_a_glance": {
+                    "health": "mixed",
+                    "whats_working": "",
+                    "whats_hindering": "",
+                    "quick_win": "",
+                    "ambitious_workflows": "",
+                }
+            }
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: recording_model)
+
+        await sections.generate_sections(
+            data_block='{"total_sessions": 3}',
+            previous_report={"total_sessions": 2},
+        )
+
+        regression_prompts = [p for p in prompts_seen if "regression_detection" in p]
+        assert regression_prompts
+        assert "Previous Period Metrics" in regression_prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_catalog_block_included_for_suggestions(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        prompts_seen: list[str] = []
+
+        async def recording_model(prompt: str, **kwargs) -> dict:
+            prompts_seen.append(prompt)
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: recording_model)
+
+        catalog = {"skills": [{"id": "scope-guard", "description": "guards scope"}]}
+        await sections.generate_sections(data_block='{"total_sessions": 3}', registry_catalog=catalog)
+
+        suggestion_prompts = [p for p in prompts_seen if "suggestions" in p.lower() and "scope-guard" in p]
+        assert suggestion_prompts
+
+    @pytest.mark.asyncio
+    async def test_deep_sections_use_section_model(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        # Return "opus" for section model, "sonnet" for synthesis
+        async def fake_get(key: str):
+            if key == "insights.model_sections":
+                return "claude-opus-special"
+            if key == "insights.model_synthesis":
+                return "claude-sonnet-special"
+            return None
+
+        monkeypatch.setattr(ds, "get", fake_get)
+
+        model_overrides_seen: list[str | None] = []
+
+        async def recording_model(prompt: str, **kwargs) -> dict:
+            model_overrides_seen.append(kwargs.get("model_override"))
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: recording_model)
+
+        await sections.generate_sections(data_block='{"total_sessions": 1}')
+
+        # At least one deep section should have used "claude-opus-special"
+        assert "claude-opus-special" in model_overrides_seen
+
+    @pytest.mark.asyncio
+    async def test_synthesis_failure_sets_empty_at_a_glance(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        call_count = {"n": 0}
+
+        async def always_fail(prompt: str, **kwargs) -> dict:
+            call_count["n"] += 1
+            raise Exception("synthesis exploded")
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: always_fail)
+
+        result = await sections.generate_sections(data_block='{"total_sessions": 1}')
+        assert result.get("at_a_glance") == {}
+
+    @pytest.mark.asyncio
+    async def test_section_result_stored_under_correct_key(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        async def canned_model(prompt: str, **kwargs) -> dict:
+            if "what_works" in prompt:
+                return {"what_works": {"intro": "it works great", "strengths": []}}
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: canned_model)
+
+        result = await sections.generate_sections(data_block='{"total_sessions": 5}')
+        assert result.get("what_works", {}).get("intro") == "it works great"

--- a/tests/test_insights_pricing.py
+++ b/tests/test_insights_pricing.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pricing — cost tracking and model-tier classification in enrichment.
+
+Covers: per-model cost aggregation in extract_session_meta, cost totals in
+aggregate_metas, model tier classification (subscription vs metered),
+and cost formatting helpers in html_export.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights pricing tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+def _raw(entry: dict) -> str:
+    return json.dumps(entry)
+
+
+def _assistant_with_cost(model: str, input_tokens: int, output_tokens: int, cost: float) -> str:
+    return _raw(
+        {
+            "type": "message",
+            "timestamp": "2026-01-01T10:00:00Z",
+            "message": {
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "usage": {
+                    "input": input_tokens,
+                    "output": output_tokens,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                    "cost": {"total": cost},
+                },
+            },
+        }
+    )
+
+
+class TestCostExtractionFromRawLines:
+    def test_single_model_cost_tracked(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_with_cost("claude-haiku", 1000, 200, 0.05)]
+        meta = extract_session_meta("s1", lines)
+        assert meta["total_cost"] == pytest.approx(0.05)
+
+    def test_multiple_messages_costs_summed(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [
+            _assistant_with_cost("claude-haiku", 1000, 200, 0.02),
+            _assistant_with_cost("claude-haiku", 2000, 400, 0.04),
+        ]
+        meta = extract_session_meta("s1", lines)
+        assert meta["total_cost"] == pytest.approx(0.06)
+
+    def test_input_tokens_aggregated(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_with_cost("claude-haiku", 500, 0, 0.0), _assistant_with_cost("claude-haiku", 300, 0, 0.0)]
+        meta = extract_session_meta("s1", lines)
+        assert meta["input_tokens"] == 800
+
+    def test_output_tokens_aggregated(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [_assistant_with_cost("claude-haiku", 0, 100, 0.0), _assistant_with_cost("claude-haiku", 0, 200, 0.0)]
+        meta = extract_session_meta("s1", lines)
+        assert meta["output_tokens"] == 300
+
+    def test_cache_tokens_aggregated(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        line = _raw(
+            {
+                "type": "message",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-haiku",
+                    "content": [],
+                    "usage": {
+                        "input": 0,
+                        "output": 0,
+                        "cacheRead": 500,
+                        "cacheWrite": 1000,
+                        "cost": {},
+                    },
+                },
+            }
+        )
+        meta = extract_session_meta("s1", [line])
+        assert meta["cache_read_tokens"] == 500
+        assert meta["cache_write_tokens"] == 1000
+
+    def test_per_model_usage_tracked_separately(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        lines = [
+            _assistant_with_cost("claude-haiku", 1000, 200, 0.01),
+            _assistant_with_cost("claude-opus", 2000, 500, 0.10),
+        ]
+        meta = extract_session_meta("s1", lines)
+        assert "claude-haiku" in meta["model_usage"]
+        assert "claude-opus" in meta["model_usage"]
+        assert meta["model_usage"]["claude-opus"]["cost"] == pytest.approx(0.10)
+
+    def test_zero_cost_messages_still_tracked_by_model(self):
+        from services.insights.session_meta_extractor import extract_session_meta
+
+        line = _raw(
+            {
+                "type": "message",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-haiku",
+                    "content": [],
+                },
+            }
+        )
+        meta = extract_session_meta("s1", [line])
+        assert "claude-haiku" in meta["model_usage"]
+        assert meta["model_usage"]["claude-haiku"]["messages"] == 1
+
+
+class TestModelTierClassification:
+    """Model tier classification in aggregate_metas."""
+
+    def _make_meta_with_model(self, model: str, input_t: int, output_t: int, cost: float) -> dict:
+        return {
+            "session_id": "s1",
+            "total_messages": 5,
+            "duration_seconds": 60.0,
+            "input_tokens": input_t,
+            "output_tokens": output_t,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "total_cost": cost,
+            "credits": 0.0,
+            "lines_added": 0,
+            "lines_removed": 0,
+            "files_modified": 0,
+            "git_commits": 0,
+            "git_pushes": 0,
+            "tool_errors": 0,
+            "user_interruptions": 0,
+            "uses_subagent": False,
+            "uses_mcp": False,
+            "tool_counts": {},
+            "languages": {},
+            "tool_error_categories": {},
+            "model_usage": {model: {"input_tokens": input_t, "output_tokens": output_t, "cost": cost, "messages": 10}},
+            "project_path": "",
+            "user_response_times": [],
+            "message_hours": [],
+            "start_time": "2026-01-01T10:00:00Z",
+            "harness": "",
+            "user_message_count": 3,
+            "user_message_timestamps": [],
+            "layer_hash": "",
+            "agent_version": "",
+        }
+
+    def test_high_token_zero_cost_is_subscription(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        meta = self._make_meta_with_model("claude-pro-sub", 200_000, 50_000, 0.0)
+        agg = aggregate_metas([meta])
+        assert agg["model_tiers"].get("claude-pro-sub") == "subscription"
+
+    def test_paid_model_not_subscription(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        meta = self._make_meta_with_model("claude-opus-4", 50_000, 10_000, 2.50)
+        agg = aggregate_metas([meta])
+        tier = agg["model_tiers"].get("claude-opus-4")
+        assert tier != "subscription"
+
+    def test_expensive_model_classified_as_high(self):
+        """A model with cost-per-1k-token 3x above median → high tier."""
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        # cheap model: 100k tokens for $0.01 → very low cpt
+        cheap = self._make_meta_with_model("cheap-model", 50_000, 50_000, 0.01)
+        # expensive model: 10k tokens for $10 → high cpt
+        expensive = self._make_meta_with_model("expensive-model", 5_000, 5_000, 10.0)
+        agg = aggregate_metas([cheap, expensive])
+        # Multiple sessions needed to set median; expensive should be "high" relative to cheap
+        assert agg["model_tiers"].get("expensive-model") in ("high", "mid")  # at least not low
+
+    def test_total_cost_sums_across_sessions(self):
+        from services.insights.session_meta_extractor import aggregate_metas
+
+        metas = [
+            self._make_meta_with_model("haiku", 1000, 200, 0.05),
+            self._make_meta_with_model("haiku", 1000, 200, 0.05),
+            self._make_meta_with_model("haiku", 1000, 200, 0.05),
+        ]
+        agg = aggregate_metas(metas)
+        assert agg["total_cost"] == pytest.approx(0.15)
+
+
+class TestCostFormattingHelpers:
+    """Edge cases for the cost formatting helpers in html_export."""
+
+    def test_format_cost_zero(self):
+        from services.insights.html_export import _format_cost
+
+        # 0.0 < 0.01, so 4 decimal places are shown
+        assert _format_cost(0.0) == "$0.0000"
+
+    def test_format_cost_sub_cent(self):
+        from services.insights.html_export import _format_cost
+
+        result = _format_cost(0.0042)
+        assert result.startswith("$")
+        assert "0042" in result  # 4 decimal places
+
+    def test_format_cost_whole_dollar(self):
+        from services.insights.html_export import _format_cost
+
+        assert _format_cost(5.0) == "$5.00"
+
+    def test_format_cost_large_value(self):
+        from services.insights.html_export import _format_cost
+
+        assert _format_cost(1234.56) == "$1234.56"
+
+    def test_format_cost_none_is_zero(self):
+        from services.insights.html_export import _format_cost
+
+        assert _format_cost(None) == "$0.00"
+
+    def test_format_number_millions(self):
+        from services.insights.html_export import _format_number
+
+        assert _format_number(1_500_000) == "1,500,000"
+
+    def test_format_number_zero(self):
+        from services.insights.html_export import _format_number
+
+        assert _format_number(0) == "0"

--- a/tests/test_insights_regression.py
+++ b/tests/test_insights_regression.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 22026 Santhiya Manivannan <santhiyamalar20@gmail.com>
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for regression detection — sections regression prompt + version_impact helpers.
+
+Covers: the regression_detection section prompt data forwarding, period-over-period
+change detection signals in generate_sections, and version comparison section routing.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights regression tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+class TestRegressionDetectionSection:
+    """Verify regression_detection section prompt is built correctly."""
+
+    @pytest.mark.asyncio
+    async def test_no_previous_data_produces_has_previous_false(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        prompts_captured: list[str] = []
+
+        async def recording_model(prompt: str, **kwargs) -> dict:
+            prompts_captured.append(prompt)
+            if "regression_detection" in prompt:
+                return {
+                    "regression_detection": {"has_previous_data": False, "summary": "No previous data.", "changes": []}
+                }
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: recording_model)
+
+        result = await sections.generate_sections(data_block='{"total_sessions": 5}', previous_report=None)
+
+        reg = result.get("regression_detection") or {}
+        # Either the section returned has_previous_data=False, or generate_sections
+        # propagated an empty dict (both are acceptable — what matters is no crash)
+        if reg:
+            assert reg.get("has_previous_data") is False or "changes" in reg
+
+    @pytest.mark.asyncio
+    async def test_previous_data_included_in_prompt(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        prompts_captured: list[str] = []
+
+        async def recording_model(prompt: str, **kwargs) -> dict:
+            prompts_captured.append(prompt)
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: recording_model)
+
+        prev_report = {"total_sessions": 3, "total_cost": 0.15}
+        await sections.generate_sections(
+            data_block='{"total_sessions": 5}',
+            previous_report=prev_report,
+        )
+
+        regression_prompts = [p for p in prompts_captured if "regression_detection" in p]
+        assert regression_prompts, "regression_detection prompt must be sent"
+        prompt = regression_prompts[0]
+        assert "Previous Period Metrics" in prompt
+        assert "total_sessions" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_previous_data_block_says_unavailable(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        prompts_captured: list[str] = []
+
+        async def recording_model(prompt: str, **kwargs) -> dict:
+            prompts_captured.append(prompt)
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: recording_model)
+
+        await sections.generate_sections(data_block='{"total_sessions": 2}', previous_report=None)
+
+        regression_prompts = [p for p in prompts_captured if "regression_detection" in p]
+        assert regression_prompts
+        assert "No previous period data available" in regression_prompts[0]
+
+
+class TestVersionComparisonSection:
+    @pytest.mark.asyncio
+    async def test_version_comparison_section_included_in_output(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        async def canned_model(prompt: str, **kwargs) -> dict:
+            if "version_comparison" in prompt:
+                return {
+                    "version_comparison": {
+                        "has_comparison": True,
+                        "current_version": "1.1.0",
+                        "prior_version": "1.0.0",
+                        "summary": "Metrics improved.",
+                        "confidence": "medium",
+                        "changes": [],
+                    }
+                }
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: canned_model)
+
+        result = await sections.generate_sections(data_block='{"total_sessions": 10}')
+        vc = result.get("version_comparison") or {}
+        # When the canned response is returned, it should be stored
+        if vc:
+            assert vc.get("has_comparison") is True
+
+    @pytest.mark.asyncio
+    async def test_version_comparison_no_comparison_case(self, monkeypatch):
+        import services.dynamic_settings as ds
+        from services.insights import sections
+
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        async def canned_model(prompt: str, **kwargs) -> dict:
+            if "version_comparison" in prompt:
+                return {
+                    "version_comparison": {
+                        "has_comparison": False,
+                        "summary": "No prior approved version cohort was available.",
+                        "confidence": "insufficient_data",
+                        "changes": [],
+                    }
+                }
+            return {}
+
+        monkeypatch.setattr(sections, "get_call_model", lambda: canned_model)
+
+        result = await sections.generate_sections(data_block='{"total_sessions": 2}')
+        vc = result.get("version_comparison") or {}
+        if vc:
+            assert vc.get("has_comparison") is False
+
+
+class TestVersionImpactMedianMAD:
+    """Unit tests for the statistical helpers used in regression detection."""
+
+    def test_mad_based_z_score_robust_to_outlier(self):
+        """A single extreme outlier should not shift other groups out of 'normal'."""
+        from services.insights.version_impact import _robust_outlier_labels
+
+        groups = [
+            {"layer_hash": "n1", "success_proxy": 0.80},
+            {"layer_hash": "n2", "success_proxy": 0.81},
+            {"layer_hash": "n3", "success_proxy": 0.79},
+            {"layer_hash": "extreme", "success_proxy": 0.0},  # outlier
+        ]
+        labels = _robust_outlier_labels(groups, "success_proxy")
+        # Normal groups should remain 'normal'; outlier should be flagged
+        assert labels["n1"] == "normal"
+        assert labels["extreme"] == "negative_outlier"
+
+    def test_all_identical_values_all_normal(self):
+        from services.insights.version_impact import _robust_outlier_labels
+
+        groups = [{"layer_hash": f"h{i}", "success_proxy": 0.80} for i in range(5)]
+        labels = _robust_outlier_labels(groups, "success_proxy")
+        assert all(v == "normal" for v in labels.values())
+
+    def test_confidence_medium_for_moderate_data(self):
+        from services.insights.version_impact import _confidence_for_groups
+
+        # 20 sessions total, 1 multi-user group
+        groups = [
+            {"layer_hash": "h1", "sessions": 10, "users": 2},
+            {"layer_hash": "h2", "sessions": 10, "users": 1},
+        ]
+        result = _confidence_for_groups(groups, significant=True)
+        # 20 sessions, only 1 multi-user group → medium confidence
+        assert result == "medium"

--- a/tests/test_insights_regression.py
+++ b/tests/test_insights_regression.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 22026 Santhiya Manivannan <santhiyamalar20@gmail.com>
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <santhiyamalar20@gmail.com>
 # SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_insights_session_cache.py
+++ b/tests/test_insights_session_cache.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for session_cache — facets DB caching layer.
+
+Covers extract_and_cache_facets (hit/miss paths), store_facets
+(insert vs update), and load_cached_facets single-session wrapper.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights session_cache tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+def _facet_data() -> dict:
+    return {
+        "underlying_goal": "add a feature",
+        "goal_categories": ["implement_feature"],
+        "outcome": "fully_achieved",
+        "user_satisfaction": "happy",
+        "agent_helpfulness": "essential",
+        "session_type": "single_task",
+        "complexity": "medium",
+        "friction_points": [],
+        "primary_success_factors": ["correct_code_edits"],
+        "tools_effective": ["edit"],
+        "tools_problematic": [],
+        "repeated_instructions": [],
+        "brief_summary": "User added a feature successfully.",
+    }
+
+
+class TestExtractAndCacheFacets:
+    @pytest.mark.asyncio
+    async def test_returns_cached_facets_when_available(self, monkeypatch):
+        from services.insights import facets
+
+        cached = _facet_data()
+        monkeypatch.setattr(facets, "load_cached_facets", AsyncMock(return_value=cached))
+        extract_mock = AsyncMock()
+        monkeypatch.setattr(facets, "extract_facets", extract_mock)
+
+        result = await facets.extract_and_cache_facets("s1", "transcript...", {}, "agent-1", MagicMock())
+        assert result == cached
+        extract_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_calls_extract_when_not_cached(self, monkeypatch):
+        from services.insights import facets
+
+        monkeypatch.setattr(facets, "load_cached_facets", AsyncMock(return_value=None))
+        expected = _facet_data()
+        extract_mock = AsyncMock(return_value=expected)
+        store_mock = AsyncMock()
+        monkeypatch.setattr(facets, "extract_facets", extract_mock)
+        monkeypatch.setattr(facets, "store_facets", store_mock)
+
+        result = await facets.extract_and_cache_facets("s1", "x" * 200, {}, "agent-1", MagicMock())
+        assert result == expected
+        extract_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stores_facets_after_extraction(self, monkeypatch):
+        from services.insights import facets
+
+        monkeypatch.setattr(facets, "load_cached_facets", AsyncMock(return_value=None))
+        extracted = _facet_data()
+        monkeypatch.setattr(facets, "extract_facets", AsyncMock(return_value=extracted))
+        store_mock = AsyncMock()
+        monkeypatch.setattr(facets, "store_facets", store_mock)
+
+        db = MagicMock()
+        await facets.extract_and_cache_facets("s1", "x" * 200, {}, "agent-1", db)
+
+        store_mock.assert_called_once_with("s1", "agent-1", extracted, db)
+
+    @pytest.mark.asyncio
+    async def test_does_not_store_when_extraction_returns_empty(self, monkeypatch):
+        from services.insights import facets
+
+        monkeypatch.setattr(facets, "load_cached_facets", AsyncMock(return_value=None))
+        monkeypatch.setattr(facets, "extract_facets", AsyncMock(return_value={}))
+        store_mock = AsyncMock()
+        monkeypatch.setattr(facets, "store_facets", store_mock)
+
+        await facets.extract_and_cache_facets("s1", "x" * 200, {}, "agent-1", MagicMock())
+        store_mock.assert_not_called()
+
+
+class TestStoreFacets:
+    @pytest.mark.asyncio
+    async def test_creates_new_record_when_none_exists(self, monkeypatch):
+        from services.insights import facets as f_mod
+
+        fake_facets_model = MagicMock()
+        new_record_instance = MagicMock()
+        fake_facets_model.return_value = new_record_instance
+        monkeypatch.setattr(f_mod, "get_facets_model", lambda: fake_facets_model)
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        _agent_id = "550e8400-e29b-41d4-a716-446655440000"
+        with patch("sqlalchemy.select", return_value=MagicMock(where=MagicMock(return_value=MagicMock()))):
+            await f_mod.store_facets("s1", _agent_id, _facet_data(), mock_db)
+
+        mock_db.add.assert_called_once_with(new_record_instance)
+        mock_db.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_record(self, monkeypatch):
+        from services.insights import facets as f_mod
+
+        fake_facets_model = MagicMock()
+        monkeypatch.setattr(f_mod, "get_facets_model", lambda: fake_facets_model)
+
+        existing = MagicMock()
+        existing.facets = {}
+        existing.extracted_at = None
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        _agent_id = "550e8400-e29b-41d4-a716-446655440000"
+        new_data = _facet_data()
+        with patch("sqlalchemy.select", return_value=MagicMock(where=MagicMock(return_value=MagicMock()))):
+            await f_mod.store_facets("s1", _agent_id, new_data, mock_db)
+
+        assert existing.facets == new_data
+        assert existing.extracted_at is not None
+        mock_db.add.assert_not_called()
+        mock_db.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_none_agent_id(self, monkeypatch):
+        from services.insights import facets as f_mod
+
+        fake_facets_model = MagicMock()
+        fake_facets_model.return_value = MagicMock()
+        monkeypatch.setattr(f_mod, "get_facets_model", lambda: fake_facets_model)
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        # Should not raise even when agent_id is empty/None
+        with patch("sqlalchemy.select", return_value=MagicMock(where=MagicMock(return_value=MagicMock()))):
+            await f_mod.store_facets("s1", "", _facet_data(), mock_db)
+        mock_db.flush.assert_called_once()
+
+
+class TestLoadCachedFacets:
+    @pytest.mark.asyncio
+    async def test_single_session_wrapper_delegates_to_batch(self, monkeypatch):
+        from services.insights import facets as f_mod
+
+        cached = _facet_data()
+        batch_mock = AsyncMock(return_value={"s1": cached})
+        monkeypatch.setattr(f_mod, "load_cached_facets_batch", batch_mock)
+
+        result = await f_mod.load_cached_facets("s1", MagicMock())
+        assert result == cached
+        batch_mock.assert_called_once()
+        assert batch_mock.call_args[0][0] == ["s1"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_session_not_found(self, monkeypatch):
+        from services.insights import facets as f_mod
+
+        monkeypatch.setattr(f_mod, "load_cached_facets_batch", AsyncMock(return_value={}))
+
+        result = await f_mod.load_cached_facets("missing-session", MagicMock())
+        assert result is None

--- a/tests/test_insights_transcript.py
+++ b/tests/test_insights_transcript.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2026 Santhiya Manivannan <70739919+sanraj2000@users.noreply.github.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for transcript.py — session transcript builder from ClickHouse events.
+
+Covers: _format_rows, _format_event, extraction helpers, build_session_transcript
+(short/long/summarized paths).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEPLOYMENT_MODE") != "enterprise",
+    reason="Insights transcript tests require DEPLOYMENT_MODE=enterprise",
+)
+
+
+def _row(event_type: str, raw_line: dict, tool_name: str = "") -> dict:
+    return {
+        "line_offset": 0,
+        "event_type": event_type,
+        "tool_name": tool_name,
+        "raw_line": json.dumps(raw_line),
+    }
+
+
+class TestFormatEvent:
+    def test_user_prompt_string_content(self):
+        from services.insights.transcript import _format_event
+
+        parsed = {"message": {"content": "fix the bug"}}
+        line = _format_event("user_prompt", "", parsed)
+        assert line == "[User]: fix the bug"
+
+    def test_user_prompt_content_list(self):
+        from services.insights.transcript import _format_event
+
+        parsed = {"message": {"content": [{"type": "text", "text": "hello world"}]}}
+        line = _format_event("user_prompt", "", parsed)
+        assert line == "[User]: hello world"
+
+    def test_user_prompt_truncated_to_max_chars(self):
+        from services.insights.transcript import MAX_PROMPT_CHARS, _format_event
+
+        long_text = "a" * (MAX_PROMPT_CHARS + 100)
+        parsed = {"message": {"content": long_text}}
+        line = _format_event("user_prompt", "", parsed)
+        assert len(line) <= len("[User]: ") + MAX_PROMPT_CHARS
+
+    def test_assistant_text_string(self):
+        from services.insights.transcript import _format_event
+
+        parsed = {"message": {"content": "I will fix it"}}
+        line = _format_event("assistant_text", "", parsed)
+        assert line.startswith("[Assistant]:")
+        assert "I will fix it" in line
+
+    def test_tool_call_with_tool_name_field(self):
+        from services.insights.transcript import _format_event
+
+        parsed = {"input": {"command": "ls -la /repo"}}
+        line = _format_event("tool_call", "bash", parsed)
+        assert "[Tool: bash]" in line
+        assert "ls -la /repo" in line
+
+    def test_tool_call_extracts_name_from_parsed(self):
+        from services.insights.transcript import _format_event
+
+        parsed = {"name": "edit", "input": {"path": "/app/main.py"}}
+        line = _format_event("tool_call", "", parsed)
+        assert "[Tool: edit]" in line
+        assert "file: /app/main.py" in line
+
+    def test_tool_result_error_included(self):
+        from services.insights.transcript import _format_event
+
+        parsed = {"is_error": True, "content": "command failed"}
+        line = _format_event("tool_result", "bash", parsed)
+        assert "ERROR" in line
+        assert "command failed" in line
+
+    def test_tool_result_non_error_returns_empty(self):
+        from services.insights.transcript import _format_event
+
+        parsed = {"is_error": False, "content": "ok"}
+        line = _format_event("tool_result", "bash", parsed)
+        assert line == ""
+
+    def test_unknown_event_type_returns_empty(self):
+        from services.insights.transcript import _format_event
+
+        line = _format_event("session_start", "", {})
+        assert line == ""
+
+
+class TestExtractHelpers:
+    def test_extract_text_from_string_content(self):
+        from services.insights.transcript import _extract_text
+
+        assert _extract_text({"message": {"content": "hello"}}) == "hello"
+
+    def test_extract_text_from_list_content(self):
+        from services.insights.transcript import _extract_text
+
+        parsed = {"message": {"content": [{"type": "text", "text": "part1"}, {"type": "text", "text": "part2"}]}}
+        assert _extract_text(parsed) == "part1 part2"
+
+    def test_extract_text_ignores_non_text_blocks(self):
+        from services.insights.transcript import _extract_text
+
+        parsed = {
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "bash"},
+                    {"type": "text", "text": "only this"},
+                ]
+            }
+        }
+        assert _extract_text(parsed) == "only this"
+
+    def test_extract_tool_name_from_direct_field(self):
+        from services.insights.transcript import _extract_tool_name
+
+        assert _extract_tool_name({"name": "edit"}) == "edit"
+
+    def test_extract_tool_name_from_content_array(self):
+        from services.insights.transcript import _extract_tool_name
+
+        parsed = {"message": {"content": [{"type": "tool_use", "name": "write", "input": {}}]}}
+        assert _extract_tool_name(parsed) == "write"
+
+    def test_extract_tool_name_returns_empty_when_absent(self):
+        from services.insights.transcript import _extract_tool_name
+
+        assert _extract_tool_name({}) == ""
+
+    def test_extract_tool_input_command(self):
+        from services.insights.transcript import _extract_tool_input
+
+        assert _extract_tool_input({"input": {"command": "echo hi"}}) == "echo hi"
+
+    def test_extract_tool_input_file_path(self):
+        from services.insights.transcript import _extract_tool_input
+
+        assert _extract_tool_input({"input": {"path": "/a/b.py"}}) == "file: /a/b.py"
+
+    def test_extract_tool_input_from_content_array(self):
+        from services.insights.transcript import _extract_tool_input
+
+        parsed = {"message": {"content": [{"type": "tool_use", "input": {"command": "ls"}}]}}
+        assert _extract_tool_input(parsed) == "ls"
+
+    def test_extract_tool_result_string(self):
+        from services.insights.transcript import _extract_tool_result
+
+        assert _extract_tool_result({"content": "output text"}) == "output text"
+
+    def test_extract_tool_result_list_of_blocks(self):
+        from services.insights.transcript import _extract_tool_result
+
+        parsed = {"content": [{"type": "text", "text": "line1"}, {"type": "text", "text": "line2"}]}
+        assert _extract_tool_result(parsed) == "line1 line2"
+
+
+class TestFormatRows:
+    def test_skips_rows_with_empty_raw_line(self):
+        from services.insights.transcript import _format_rows
+
+        rows = [{"line_offset": 0, "event_type": "user_prompt", "tool_name": "", "raw_line": ""}]
+        result = _format_rows(rows)
+        assert result == ""
+
+    def test_skips_rows_with_invalid_json(self):
+        from services.insights.transcript import _format_rows
+
+        rows = [{"line_offset": 0, "event_type": "user_prompt", "tool_name": "", "raw_line": "{bad json"}]
+        result = _format_rows(rows)
+        assert result == ""
+
+    def test_formats_multiple_events(self):
+        from services.insights.transcript import _format_rows
+
+        rows = [
+            _row("user_prompt", {"message": {"content": "hello"}}),
+            _row("tool_call", {"name": "bash", "input": {"command": "ls"}}, tool_name="bash"),
+        ]
+        result = _format_rows(rows)
+        assert "[User]: hello" in result
+        assert "[Tool: bash]" in result
+
+
+class TestBuildSessionTranscript:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_query_fails(self, monkeypatch):
+        from services.insights import transcript
+
+        async def failing_query(_sql, _params):
+            raise RuntimeError("ClickHouse unavailable")
+
+        monkeypatch.setattr(transcript, "get_query", lambda: failing_query)
+        result = await transcript.build_session_transcript("s1")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_rows(self, monkeypatch):
+        from services.insights import transcript
+
+        class EmptyResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"data": []}
+
+        monkeypatch.setattr(transcript, "get_query", lambda: AsyncMock(return_value=EmptyResponse()))
+        result = await transcript.build_session_transcript("s1")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_short_transcript_directly(self, monkeypatch):
+        from services.insights import transcript
+
+        rows = [_row("user_prompt", {"message": {"content": "quick question"}})]
+
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"data": rows}
+
+        monkeypatch.setattr(transcript, "get_query", lambda: AsyncMock(return_value=Response()))
+        result = await transcript.build_session_transcript("s1")
+        assert "[User]: quick question" in result
+
+    @pytest.mark.asyncio
+    async def test_summarizes_long_transcript(self, monkeypatch):
+        """Transcripts exceeding MAX_TRANSCRIPT_CHARS are summarized via LLM."""
+        import services.dynamic_settings as ds
+        from services.insights import transcript
+
+        # Generate rows that produce a long transcript
+        big_content = "x" * 600
+        rows = [
+            {
+                "line_offset": i,
+                "event_type": "user_prompt",
+                "tool_name": "",
+                "raw_line": json.dumps({"message": {"content": big_content}}),
+            }
+            for i in range(70)
+        ]
+
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"data": rows}
+
+        summaries: list[str] = []
+
+        async def call_model(prompt: str, **kwargs) -> dict:
+            summaries.append(prompt)
+            return {"summary": "chunk summarized"}
+
+        monkeypatch.setattr(transcript, "get_query", lambda: AsyncMock(return_value=Response()))
+        monkeypatch.setattr(transcript, "get_call_model", lambda: call_model)
+        monkeypatch.setattr(ds, "get", AsyncMock(return_value=None))
+
+        result = await transcript.build_session_transcript("session-abc123")
+        assert summaries  # model was called to summarize
+        assert "[Long session summarized]" in result
+        assert "chunk summarized" in result


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Adds unit testing for the ee/observal_insights/ modules

## Fixes
* Fixes #880

## Approach
Nine test files added under `tests/`, all skipped outside enterprise mode.
External calls are mocked; no Docker stack needed.

**Files added:**
- `tests/test_insights_enrichment.py`
- `tests/test_insights_facets.py`
- `tests/test_insights_session_cache.py`
- `tests/test_insights_transcript.py`
- `tests/test_insights_html_export.py`
- `tests/test_insights_narrative.py`
- `tests/test_insights_anonymize.py`
- `tests/test_insights_regression.py`
- `tests/test_insights_pricing.py`

## How Has This Been Tested?

Skip behaviour (no env var):

```
cd observal-server
uv run --with pytest --with pytest-asyncio pytest ../tests/test_insights_*.py -q
# → 176 skipped in ~1s
```
Full run (enterprise mode):

```
cd observal-server
DEPLOYMENT_MODE=enterprise uv run --with pytest --with pytest-asyncio \
  --with pyyaml --with pyarrow \
  pytest ../tests/test_insights_enrichment.py \
         ../tests/test_insights_facets.py \
         ../tests/test_insights_html_export.py \
         ../tests/test_insights_session_cache.py \
         ../tests/test_insights_anonymize.py \
         ../tests/test_insights_transcript.py \
         ../tests/test_insights_pricing.py \
         ../tests/test_insights_regression.py \
         ../tests/test_insights_narrative.py \
  -v
# → 176 passed in ~3s
```

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): IBM bob
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive enterprise-only coverage for Insights session enrichment, transcript generation, facets, pricing, narrative sections, regression analysis, version impact, HTML exports, and session caching.
  * Validated edge cases including empty or invalid data, error handling, caching behavior, content escaping, statistical confidence, model usage, and report rendering.
  * Added regression tests for previous-period comparisons, version comparisons, and outlier detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->