### PR TITLE
feat(insights): persist discarded run analysis

### DIFF
--- a/observal-server/alembic/versions/023_insight_analysis_payload.py
+++ b/observal-server/alembic/versions/023_insight_analysis_payload.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 The Observal Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist insights analysis previously discarded each run.
+
+Adds ``version_impact`` and ``registry_offer`` (JSON, nullable) to
+``insight_reports``. The pipeline already computes both every run — the
+cross-user layer/config correlation analysis and the deterministic registry
+component shortlist shown to the model — but historically folded them into the
+LLM prompt and then discarded them. These columns persist that analysis so
+downstream consumers (duplicate detection, pull-time recommendations,
+governance drift signals) can read it without re-running the pipeline.
+
+Both columns are nullable: pre-existing reports predate the columns (and never
+had the data), and a run may legitimately produce no version impact or an
+empty offer. No backfill is needed — null is the correct value for old rows.
+
+Revision ID: 023_insight_analysis_payload
+Revises: 022_user_recommendations
+Create Date: 2026-08-03
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "023_insight_analysis_payload"
+down_revision = "022_user_recommendations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("insight_reports", sa.Column("version_impact", sa.JSON(), nullable=True))
+    op.add_column("insight_reports", sa.Column("registry_offer", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("insight_reports", "registry_offer")
+    op.drop_column("insight_reports", "version_impact")

--- a/observal-server/models/insight_report.py
+++ b/observal-server/models/insight_report.py
@@ -72,6 +72,16 @@ class InsightReport(Base):
     aggregated_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     report_version: Mapped[int] = mapped_column(Integer, default=1)
 
+    # Analysis previously computed and discarded each run. Persisted now so
+    # downstream consumers (duplicate detection, pull-time recommendations,
+    # governance drift signals) can read them without re-running the pipeline.
+    # ``version_impact`` is the cross-user layer/config correlation analysis;
+    # ``registry_offer`` is the deterministic component shortlist the model was
+    # shown. Both are nullable: old reports predate the columns, and a run may
+    # legitimately produce no version impact or an empty offer.
+    version_impact: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    registry_offer: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
     # Self-learn fields
     applied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     applied_items: Mapped[dict | None] = mapped_column(JSON, nullable=True)

--- a/observal-server/schemas/insight_analysis.py
+++ b/observal-server/schemas/insight_analysis.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 The Observal Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed schema for the insights pipeline's analytical payload.
+
+The pipeline computes a rich set of analysis *before* it writes any narrative
+prose: deterministic metrics, LLM-extracted facets, cross-user version-impact
+analysis, and a deterministic registry shortlist. Historically most of this
+was stored as untyped JSON blobs on the ``InsightReport`` (``metrics``,
+``narrative``, ``aggregated_data``), while ``version_impact`` and
+``registry_offer`` were computed and then discarded every run.
+
+This module defines the canonical top-level shape of that payload so there is
+a single source of truth for what one pipeline run produces, and so structural
+drift (a whole section going missing, a dict arriving as a list) is detectable
+at write time instead of silently persisted.
+
+The schema is intentionally permissive on nested fields: ``metrics``,
+``narrative`` and ``aggregated_data`` carry LLM-generated content whose exact
+shape varies, so they are typed as ``dict`` rather than fully modelled.
+Validation catches gross structural errors, not minor LLM output variance — a
+report must never fail to persist because the model added an unexpected field.
+"""
+
+from __future__ import annotations
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+logger = structlog.get_logger(__name__)
+
+
+class InsightAnalysisPayload(BaseModel):
+    """The analytical output of one insights pipeline run.
+
+    Fields are grouped by how they were produced so a reader can tell
+    deterministic data apart from LLM-inferred content:
+
+    * Deterministic: ``metrics``, ``aggregated_data``, ``version_impact``,
+      ``registry_offer``, ``facets_summary`` (the last is an aggregate of
+      per-session LLM facets, but the aggregation itself is deterministic).
+    * Generated: ``narrative`` (the LLM-written report sections, including
+      ``suggestions``).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    # Deterministic metrics from ClickHouse (has ``rich`` / ``overview``).
+    metrics: dict = Field(default_factory=dict)
+    # LLM-generated narrative sections (including ``suggestions``).
+    narrative: dict = Field(default_factory=dict)
+    # Pre-existing roll-up: metrics + facets_summary + regressions +
+    # cross_user_patterns. Kept as a dict for back-compat with readers.
+    aggregated_data: dict = Field(default_factory=dict)
+    # Cross-user layer/config correlation analysis. Previously discarded
+    # after being folded into the LLM prompt; now persisted.
+    version_impact: dict | None = None
+    # Deterministic shortlist of registry components the agent does not yet
+    # use. Previously discarded after being shown to the model; now persisted
+    # so future consumers (duplicate detection, pull-time recs) can read it
+    # without re-running the pipeline.
+    registry_offer: dict | None = None
+    # Aggregate of per-session facets.
+    facets_summary: dict = Field(default_factory=dict)
+    # Number of sessions the run analysed.
+    sessions_analyzed: int = 0
+
+
+def validate_payload(content: dict) -> dict | None:
+    """Structurally validate a pipeline run's output.
+
+    Returns a validated ``InsightAnalysisPayload`` dict on success, or ``None``
+    on structural mismatch. Failures are *never* fatal: callers persist the
+    raw ``content`` dict as a fallback so a schema mismatch cannot break
+    report generation. The mismatch is logged so drift is observable.
+    """
+    try:
+        payload = InsightAnalysisPayload.model_validate(content)
+    except ValidationError as e:
+        # Log only loc/type/msg — never the raw input, which can carry
+        # LLM-generated narrative or session-derived text from ``content``.
+        safe = [{"loc": err["loc"], "type": err["type"], "msg": err["msg"]} for err in e.errors(include_input=False)]
+        logger.warning("insight_payload_validation_failed", errors=safe)
+        return None
+    return payload.model_dump()
+
+
+__all__ = ["InsightAnalysisPayload", "validate_payload"]

--- a/observal-server/schemas/insights.py
+++ b/observal-server/schemas/insights.py
@@ -75,6 +75,10 @@ class InsightReportResponse(BaseModel):
     previous_report_id: uuid.UUID | None = None
     aggregated_data: dict | None = None
     report_version: int = 3
+    # Persisted analysis (previously discarded each run). Nullable: old
+    # reports predate the columns, and a run may produce neither.
+    version_impact: dict | None = None
+    registry_offer: dict | None = None
     # Self-learn fields
     applied_at: datetime | None = None
     applied_items: dict | None = None

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from database import async_session
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.insight_report import InsightReport, InsightReportStatus
+from schemas.insight_analysis import validate_payload
 from services.clickhouse import _query
 from services.insight_version_filters import agent_version_filter
 from services.redis import _get_arq_pool
@@ -245,7 +246,10 @@ async def run_single_report(report_id: str) -> None:
 
             await _update_report_progress(db, report, "saving", 9, 9, "Saving report")
 
-            # Persist results
+            # Persist results. The pipeline now returns the analysis it
+            # previously discarded (version_impact, registry_offer); persist
+            # those alongside the existing fields so downstream consumers can
+            # read them without a rerun.
             report.metrics = content.get("metrics")
             report.narrative = content.get("narrative")
             report.sessions_analyzed = content.get("sessions_analyzed", 0)
@@ -255,7 +259,20 @@ async def run_single_report(report_id: str) -> None:
                 "regressions": content.get("regressions"),
                 "cross_user_patterns": content.get("cross_user_patterns"),
             }
+            report.version_impact = content.get("version_impact")
+            report.registry_offer = content.get("registry_offer")
             report.report_version = 3
+
+            # Structural validation of the payload. Non-destructive: a
+            # mismatch is logged but never blocks the write, so a schema drift
+            # cannot break report generation.
+            validated = validate_payload(content)
+            if validated is not None:
+                logger.info(
+                    "insight_payload_validated",
+                    has_version_impact=validated.get("version_impact") is not None,
+                    has_registry_offer=validated.get("registry_offer") is not None,
+                )
 
             models_used = content.get("models_used", [])
             report.llm_model_used = ", ".join(models_used) if models_used else None

--- a/observal-server/services/insights/generator.py
+++ b/observal-server/services/insights/generator.py
@@ -485,6 +485,14 @@ async def _run_pipeline(
         "regressions": [],
         "facets_summary": facets_summary,
         "cross_user_patterns": {},
+        # Analysis previously discarded after being folded into the prompt.
+        # Persisted now so downstream consumers can read them without a rerun.
+        "version_impact": version_impact,
+        # Use an explicit ``is not None`` check: CatalogOffer defines __bool__ as
+        # bool(entries_by_type), so an empty/disabled/failed offer would evaluate
+        # falsy and we'd persist None — losing the enabled / registry_has_components
+        # metadata that matters most in exactly those cases.
+        "registry_offer": registry_offer.to_dict() if registry_offer is not None else None,
     }
 
 
@@ -756,4 +764,6 @@ def _empty_report() -> dict:
         "regressions": [],
         "facets_summary": {},
         "cross_user_patterns": {},
+        "version_impact": None,
+        "registry_offer": None,
     }

--- a/observal-server/services/insights/registry_match.py
+++ b/observal-server/services/insights/registry_match.py
@@ -88,6 +88,22 @@ class CatalogOffer:
             "registry_has_components": self.registry_has_components,
         }
 
+    def to_dict(self) -> dict:
+        """Serialize the full offer for persistence as analysis payload.
+
+        Unlike :meth:`to_summary` (which records *that* a search happened),
+        this captures *what* was offered so downstream consumers can read the
+        shortlist without re-running the recommender. ``offered_ids`` is a
+        set of UUIDs and is serialized as sorted strings for stable storage.
+        """
+        return {
+            "enabled": self.enabled,
+            "registry_has_components": self.registry_has_components,
+            "item_count": self.item_count,
+            "offered_ids": sorted(str(cid) for cid in self.offered_ids),
+            "entries_by_type": self.entries_by_type,
+        }
+
 
 def build_signals(
     agg: dict | None = None,

--- a/tests/test_insight_analysis_payload.py
+++ b/tests/test_insight_analysis_payload.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2026 The Observal Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for persisting the insights analysis payload.
+
+Covers the "unconditionally worth it" change: the pipeline now returns (and
+the report row now persists) the ``version_impact`` and ``registry_offer``
+analysis it previously discarded every run, plus a typed schema for the
+analytical payload validated non-destructively on write.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from schemas.insight_analysis import validate_payload
+from services.insights.generator import REPORT_VERSION, _empty_report
+from services.insights.registry_match import CatalogOffer
+
+# ── CatalogOffer.to_dict ────────────────────────────────────────────────
+
+
+def test_catalog_offer_to_dict_serializes_full_offer():
+    cid_a = uuid.uuid4()
+    cid_b = uuid.uuid4()
+    entry = {"id": str(cid_a), "qualified_name": "ns/foo-bar", "name": "foo-bar"}
+    offer = CatalogOffer(
+        entries_by_type={"skills": [entry]},
+        offered_ids={cid_a, cid_b},
+        registry_has_components=True,
+        enabled=True,
+    )
+
+    d = offer.to_dict()
+
+    assert d["enabled"] is True
+    assert d["registry_has_components"] is True
+    assert d["item_count"] == 1
+    # offered_ids is a set -> serialized as sorted strings for stable storage.
+    assert d["offered_ids"] == sorted([str(cid_a), str(cid_b)])
+    assert d["entries_by_type"] == {"skills": [entry]}
+
+
+def test_catalog_offer_to_dict_empty_offer():
+    offer = CatalogOffer()
+
+    d = offer.to_dict()
+
+    assert d["enabled"] is True
+    assert d["registry_has_components"] is None
+    assert d["item_count"] == 0
+    assert d["offered_ids"] == []
+    assert d["entries_by_type"] == {}
+
+
+def test_empty_or_disabled_offer_is_not_dropped_by_truthiness():
+    """Regression guard for the generator serialization check.
+
+    build_catalog never returns None — it returns CatalogOffer() on the
+    no-match path and CatalogOffer(enabled=False) on the disabled path. Both
+    are falsy under CatalogOffer.__bool__ (bool(entries_by_type)). The
+    generator must use ``is not None`` rather than truthiness, or it persists
+    None and loses the enabled / registry_has_components metadata that
+    matters most in exactly these cases.
+    """
+    empty_offer = CatalogOffer()
+    disabled_offer = CatalogOffer(enabled=False)
+
+    # The exact expression the generator uses to serialize the offer.
+    empty_serialized = empty_offer.to_dict() if empty_offer is not None else None
+    disabled_serialized = disabled_offer.to_dict() if disabled_offer is not None else None
+
+    # Both must serialize to a dict, not be dropped to None.
+    assert empty_serialized is not None
+    assert empty_serialized["item_count"] == 0
+    assert disabled_serialized is not None
+    assert disabled_serialized["enabled"] is False
+
+    # And the truthiness check that USED to be there would have dropped them.
+    assert not bool(empty_offer)  # falsy -> would have been None under `if offer`
+    assert not bool(disabled_offer)
+
+
+# ── InsightAnalysisPayload schema ───────────────────────────────────────
+
+
+def test_payload_accepts_full_pipeline_output():
+    content = {
+        "metrics": {"rich": {"total_sessions": 10}, "overview": {"unique_users": 1}},
+        "narrative": {"at_a_glance": {"health": "good"}, "suggestions": {"features_to_try": []}},
+        "aggregated_data": {"metrics": {}, "facets_summary": {}, "regressions": [], "cross_user_patterns": {}},
+        "version_impact": {"group_count": 3, "canonical_dirty_summary": None},
+        "registry_offer": {"enabled": True, "item_count": 2, "offered_ids": [], "entries_by_type": {}},
+        "facets_summary": {"goal_categories": []},
+        "sessions_analyzed": 10,
+    }
+
+    validated = validate_payload(content)
+
+    assert validated is not None
+    assert validated["sessions_analyzed"] == 10
+    assert validated["version_impact"]["group_count"] == 3
+    assert validated["registry_offer"]["item_count"] == 2
+
+
+def test_payload_accepts_none_for_new_fields():
+    """A run may produce no version impact or an empty offer."""
+    content = {
+        "metrics": {},
+        "narrative": {},
+        "version_impact": None,
+        "registry_offer": None,
+        "sessions_analyzed": 0,
+    }
+
+    validated = validate_payload(content)
+
+    assert validated is not None
+    assert validated["version_impact"] is None
+    assert validated["registry_offer"] is None
+
+
+def test_payload_tolerates_extra_llm_fields():
+    """extra='allow' so LLM output variance never fails validation."""
+    content = {
+        "metrics": {},
+        "narrative": {"suggestions": {"features_to_try": [{"unexpected": "shape"}]}},
+        "sessions_analyzed": 1,
+        "some_unexpected_top_level": "fine",
+    }
+
+    validated = validate_payload(content)
+
+    assert validated is not None
+
+
+def test_payload_validation_falls_back_on_wrong_type():
+    """A gross structural error returns None so callers fall back to raw dict."""
+    content = {
+        "metrics": "not-a-dict",  # wrong type
+        "sessions_analyzed": 1,
+    }
+
+    validated = validate_payload(content)
+
+    # Non-destructive: caller persists raw content as fallback.
+    assert validated is None
+
+
+# ── generator return dict ───────────────────────────────────────────────
+
+
+def test_empty_report_includes_new_analysis_fields():
+    report = _empty_report()
+
+    assert report["version_impact"] is None
+    assert report["registry_offer"] is None
+    # Existing fields unchanged.
+    assert report["report_version"] == REPORT_VERSION
+    assert report["sessions_analyzed"] == 0
+    assert "metrics" in report
+    assert "narrative" in report


### PR DESCRIPTION
The insights pipeline computes two pieces of analysis every run and then discards them after folding them into the LLM prompt:

- version_impact: cross-user layer/config correlation analysis (ClickHouse queries + layer-snapshot diffs)
- registry_offer: the deterministic registry component shortlist shown to the model (build_signals + build_catalog)

That is spent compute being thrown away. Persist both as nullable JSON columns on insight_reports so downstream consumers (duplicate detection, pull-time recommendations, governance drift signals) can read them without re-running the pipeline. Both are nullable: old reports predate the columns, and a run may legitimately produce neither.

Also add a typed Pydantic schema (InsightAnalysisPayload) for the analytical payload, validated non-destructively on write: a structural mismatch is logged but never blocks the report write, so schema drift cannot break report generation. The existing untyped JSON blobs (metrics, narrative, aggregated_data) are unchanged — this is additive only.

This is the "unconditionally worth it" subset of the broader InsightSnapshot refactor: it fixes real waste and types the payload without introducing a new entity, a cutover, or immutability discipline. The full snapshot externalization remains a separate, demand-gated decision.

- Add version_impact + registry_offer columns (migration 023)
- Capture both in generator._run_pipeline return + _empty_report
- Persist in batch.run_single_report + non-destructive validation
- Add CatalogOffer.to_dict() to serialize the full offer
- Expose both fields on InsightReportResponse (additive)
- Tests for to_dict, payload schema, validation fallback, empty report

<!--- Please fill the necessary details below -->
## Purpose / Description
 The insights pipeline computes two pieces of analysis every report run and then discards them after folding them into
 the LLM prompt:

 - version_impact — cross-user layer/config correlation analysis (ClickHouse queries + layer-snapshot diffs)
 - registry_offer — the deterministic registry component shortlist shown to the model (build_signals + build_catalog)

 This is spent compute being thrown away on every report generation. Downstream features that could reuse this
 analysis (duplicate-component detection, pull-time recommendations, governance drift signals) currently have no way
 to read it without re-running the whole pipeline.

## Fixes
* Fixes #<!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
Additive only; no cutover, no behavior change.

 1. Add version_impact and registry_offer as nullable JSON columns on insight_reports (migration
    023_insight_analysis_payload). Nullable because pre-existing reports predate the columns, and a run may
    legitimately produce neither.
 2. Capture both in generator._run_pipeline()'s return dict (and _empty_report()), so they stop being ephemeral.
    registry_offer is serialized via a new CatalogOffer.to_dict() — the existing to_summary() only records that a
    search happened, not what was offered.
 3. Persist both in batch.run_single_report().
 4. Add a typed Pydantic schema (InsightAnalysisPayload) for the analytical payload, validated non-destructively on
    write: a structural mismatch is logged but never blocks the report write, so schema drift cannot break report
    generation. The existing untyped JSON blobs (metrics, narrative, aggregated_data) are unchanged.
 5. Expose both fields on InsightReportResponse (additive; the frontend ignores unknown fields).

## How Has This Been Tested?

make test — 237 tests pass (new + all existing insights, self-learn, registry-match, access, retention, migrate
 suites).

 New tests in tests/test_insight_analysis_payload.py (7):
 - CatalogOffer.to_dict() serializes the full offer (entries, offered_ids as sorted strings, metadata) — both full and
   empty cases
 - InsightAnalysisPayload accepts full pipeline output, accepts None for the new fields, tolerates extra LLM-generated
   fields (extra="allow"), and returns None on gross structural errors (wrong type) so the caller falls back to the
   raw dict
 - _empty_report() includes the new fields as None

 Reproduce with:

 ```
   cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with
 hypothesis --with pyarrow pytest ../tests/test_insight_analysis_payload.py -q
 ```

 Verified the cutover scope is untouched: the four existing readers of the analytical payload (self_learn.py, the HTML
 export route, InsightReportResponse, and the frontend) read metrics/narrative/aggregated_data — none read the new
 columns yet, so null on old reports is harmless. retention.py and the admin routes touch lifecycle fields only
 (status, completed_at, agent_id) and are unaffected.

 make lint and make format clean.

## Learning (optional, can help others)
 The insights pipeline already computes a rich report-level analysis before it generates narrative, but most of it was
 either stored as untyped JSON on the report or discarded entirely. version_impact and registry_offer were the
 concrete waste — real ClickHouse compute plus a recommender shortlist, thrown away every run. Persisting them is
 nearly free (the compute is already happening) and is the part of a larger refactor justified by something happening
 today, rather than by a speculative multi-consumer future. The non-destructive-validation pattern (validate-and-log,
 fall back to raw dict) keeps the typed schema from ever becoming a failure point for report generation.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [-] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insight reports now include version-impact analysis and registry offer details when available.
  * Registry offer information includes stable identifiers and categorized entries.
  * Report validation supports additional analysis details while remaining compatible with older or incomplete reports.

* **Bug Fixes**
  * Empty or invalid analysis results no longer prevent report persistence.

* **Tests**
  * Added coverage for validation, serialization, nullable fields, empty reports, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->