### PR TITLE
Add kubeconform validation for Helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,10 +275,11 @@ jobs:
         run: |
           docker run --rm \
             -v "$PWD:/work:ro" \
-            ghcr.io/yannh/kubeconform:v0.6.7 \
+            ghcr.io/yannh/kubeconform@sha256:0925177fb05b44ce18574076141b5c3d83235e1904d3f952182ac99ddc45762c \
             -strict \
             -summary \
             -kubernetes-version 1.27.0 \
+            -schema-location 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/c8f4e61c63bc529749125ac566bccc6986e08d45/{{.NormalizedKubernetesVersion}}-standalone-strict/{{.ResourceKind}}{{.KindSuffix}}.json' \
             /work/chart-dist/rendered.yaml
 
       - name: Verify packaged chart appVersion image tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,20 @@ jobs:
 
       - name: Render chart
         if: needs.changes.outputs.helm == 'true'
-        run: helm template observal infra/helm/observal --namespace observal
+        run: |
+          mkdir -p chart-dist
+          helm template observal infra/helm/observal --namespace observal > chart-dist/rendered.yaml
+
+      - name: Validate rendered manifests
+        if: needs.changes.outputs.helm == 'true'
+        run: |
+          docker run --rm \
+            -v "$PWD:/work:ro" \
+            ghcr.io/yannh/kubeconform:v0.6.7 \
+            -strict \
+            -summary \
+            -kubernetes-version 1.27.0 \
+            /work/chart-dist/rendered.yaml
 
       - name: Verify packaged chart appVersion image tags
         if: needs.changes.outputs.helm == 'true'


### PR DESCRIPTION
## Purpose / Description
Add Kubernetes schema validation for rendered Helm chart manifests. Issue #1583 requested CI gating for Helm changes, including schema validation with kubeconform.

## Fixes
- Fixes #1583

## Approach
The existing Helm CI job already runs `helm lint` and `helm template`. This change writes the rendered chart to `chart-dist/rendered.yaml` and validates it with `ghcr.io/yannh/kubeconform:v0.6.7` using strict Kubernetes 1.27 schemas, matching the documented minimum supported cluster version.

## How Has This Been Tested?
Ran locally:

```bash
helm template observal infra/helm/observal --namespace observal > /tmp/observal-rendered.yaml
docker run --rm -v /tmp:/work:ro ghcr.io/yannh/kubeconform:v0.6.7 -strict -summary -kubernetes-version 1.27.0 /work/observal-rendered.yaml
```

Result:

```text
Summary: 22 resources found in 1 file - Valid: 22, Invalid: 0, Errors: 0, Skipped: 0
```

## Learning (optional, can help others)
The chart already had Helm lint and render checks. Kubeconform adds API schema validation over the rendered manifests.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [ ] Yes(Please Specify the tool): No
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Helm chart validation by checking rendered manifests against Kubernetes 1.27 standards.
  * Enabled stricter validation to catch configuration and compatibility issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->