### PR TITLE
docs: reword README hero tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
  ╚═════╝ ╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚═╝  ╚═╝╚══════╝
 </pre>
 
-**Observal is the control plane and system of record for internal AI components**
+**Observal is self-hosted registry for your coding agent extensions with a built in insight engine.** Setup Observal, define the scope and share your Skills, MCPs and Agents with your peers.
 
 <p>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License"></a>


### PR DESCRIPTION
## Purpose / Description
Rewords the README hero tagline (the single line under the ASCII banner) to describe Observal as a self-hosted registry for coding-agent extensions with a built-in insight engine, which better matches how the project is positioned.

## Fixes
N/A - no tracking issue; trivial docs copy change.

## Approach
Replaced only the one tagline line in `README.md`. First sentence stays the bold hero line; the second is the subtitle, consistent with the existing styling. No other content touched.

**Before**
> Observal is the control plane and system of record for internal AI components

**After**
> Observal is self-hosted registry for your coding agent extensions with a built in insight engine. Setup Observal, define the scope and share your Skills, MCPs and Agents with your peers.

## How Has This Been Tested?
Docs-only change. Verified the diff is a single line and the Markdown renders as a bold tagline + subtitle. No code paths affected.

## Checklist
- [x] Descriptive commit message with a short title (first line, max 50 chars)
- [x] Commented code in hard-to-understand areas (n/a, docs only)
- [x] Performed a self-review
- [ ] UI changes: screenshots (n/a, no UI change)

## AI Assistance
- [x] Yes (tool): Kiro CLI, used interactively under the maintainer's direction
- [x] The change was manually reviewed by the maintainer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README tagline to better describe Observal’s self-hosted registry and insight engine for sharing Skills, MCPs, and Agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->