### PR TITLE
feat(cli): auto-install Pi extension, report stale npm/local versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- SPDX-FileCopyrightText: 2026 SrihariLegend <sriharilegend23@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 DoomsCoder <vedantkakade05@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn> -->
+<!-- SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Changelog
@@ -63,6 +64,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- auto-install the bundled Pi telemetry extension during login and report stale npm or local installs (#1602)
 - add an authenticated JSON API escape hatch and mixed Registry component bulk submission
 - standardize dedicated list JSON output with `items`, `total`, `page`, and `page_size`
 - make mutation retry behavior explicit and reserve automatic transient retries for reads

--- a/docs/reference/config-files.md
+++ b/docs/reference/config-files.md
@@ -1,6 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Config files
@@ -117,6 +118,21 @@ Each list invocation replaces this cache, including an empty result. Numeric row
 | Path | Purpose |
 | --- | --- |
 | `AGENTS.md` | Rules (rules-only integration) |
+
+### Pi
+
+| Path | Purpose |
+| --- | --- |
+| `~/.pi/agent/extensions/observal.ts` | Bundled telemetry extension, installed locally when npm isn't configured |
+| `~/.pi/agent/extensions/.observal-extension.json` | Manifest recording the CLI version the local extension was installed from |
+| `~/.pi/agent/settings.json` | Pi's own config; a `packages` entry of `npm:observal-pi[@version]` here selects the npm installation mode instead |
+
+Two mutually exclusive installation modes are supported:
+
+- **npm**: `npm:observal-pi` is configured in `~/.pi/agent/settings.json` (with or without a pinned version, and whether or not Pi has downloaded it yet). Observal never writes to `extensions/observal.ts` in this mode — `observal doctor` only reports when a pinned version is older than the installed CLI, with a `pi update npm:observal-pi` reminder.
+- **local**: no npm package is configured. `observal auth login` and `observal doctor patch` install the extension bundled with the CLI directly to `extensions/observal.ts`, recording the installed CLI version in the adjacent manifest. A later CLI upgrade refreshes both files atomically and prints a reminder to restart Pi or run `/reload`; a newer local install than the current CLI is left alone.
+
+If `extensions/observal.ts` exists without a matching manifest and its contents don't match the bundled source, Observal treats it as unmanaged and never overwrites or removes it — remove or move the file aside, then re-run `observal doctor patch --harness pi` to let Observal manage it.
 
 ## Safe writes
 

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -10,6 +10,7 @@
 # SPDX-FileCopyrightText: 2026 Swathi Saravanan <ss4522@cornell.edu>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 # SPDX-FileCopyrightText: 2026 Riya Rani <rr1182764@gmail.com>
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Auth & config CLI commands."""
@@ -1450,8 +1451,9 @@ def register_config(app: typer.Typer):
 
 
 def _post_login_setup():
-    """Post-login setup: install skills unconditionally, then run doctor."""
+    """Post-login setup: install skills and the Pi extension unconditionally, then run doctor."""
     _install_observal_skill()
+    _install_or_check_pi_extension()
     _generate_initial_layer_snapshot()
     rprint()
     try:
@@ -1541,6 +1543,34 @@ def _install_observal_skill():
     from observal_cli.skill_installer import install_observal_skill
 
     install_observal_skill()
+
+
+def _install_or_check_pi_extension():
+    """Install or refresh the bundled Pi telemetry extension when Pi is detected.
+
+    Runs unconditionally (no prompt), mirroring skill install. An npm-configured
+    install is left untouched (only reported if stale). Never blocks login -
+    failures are printed and swallowed.
+    """
+    try:
+        from observal_cli import pi_extension
+
+        status = pi_extension.check_status()
+        if status.state == pi_extension.NOT_DETECTED:
+            return
+        if status.action in ("install", "refresh"):
+            pi_extension.install_or_refresh(dry_run=False)
+            verb = "Installed" if status.action == "install" else "Updated"
+            rprint(f"[green]✓ {verb} the Pi telemetry extension.[/green]")
+            if status.action == "refresh":
+                rprint("  [dim]Restart Pi or run /reload to activate.[/dim]")
+        elif status.action == "adopt":
+            pi_extension.install_or_refresh(dry_run=False)
+        elif status.message:
+            rprint(f"[yellow]{esc(status.message)}[/yellow]")
+    except Exception as exc:
+        rprint(f"[yellow]Could not check the Pi telemetry extension: {exc}[/yellow]")
+        rprint("  Run [bold]observal doctor[/bold] manually to check it.")
 
 
 def _run_doctor_patch(ide_name: str):

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
 # SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """observal doctor: diagnose and patch harness settings for Observal session telemetry.
@@ -29,7 +30,7 @@ from loguru import logger as optic
 from rich import print as rprint
 from typer.models import OptionInfo
 
-from observal_cli import config
+from observal_cli import config, pi_extension
 from observal_cli.errors import ErrorCategory, fail
 from observal_cli.harness import ensure_loaded, get_adapter
 from observal_cli.harness_specs.claude_code_hooks_spec import (
@@ -352,63 +353,23 @@ def _check_kiro(issues: list, warnings: list):
         )
 
 
-def _pi_extension_source() -> str:
-    bundled = Path(__file__).parent / "_bundled" / "observal.ts"
-    source_tree = Path(__file__).parents[1] / "packages" / "pi-extension" / "extensions" / "observal.ts"
-    for path in (bundled, source_tree):
-        if path.exists():
-            return path.read_text()
-    raise FileNotFoundError("Bundled Pi telemetry extension is missing")
-
-
-def _pi_extension_path() -> Path:
-    return Path.home() / ".pi" / "agent" / "extensions" / "observal.ts"
-
-
-def _is_legacy_pi_package(package) -> bool:
-    if isinstance(package, str):
-        source = package
-    elif isinstance(package, dict):
-        source = package.get("source", "")
-    else:
-        return False
-    return source == "npm:observal-pi" or source.startswith("npm:observal-pi@")
-
-
 def _check_pi(issues: list, warnings: list):
-    """Check whether the bundled Pi telemetry extension is current."""
+    """Check whether the Pi telemetry extension (npm or local) is current."""
     optic.debug("_check_pi")
-    pi_dir = Path.home() / ".pi" / "agent"
-    if not pi_dir.exists():
+    try:
+        status = pi_extension.check_status()
+    except json.JSONDecodeError:
+        issues.append(f"{pi_extension.settings_path()}: not valid JSON.")
+        return
+    except (OSError, ValueError, TypeError) as exc:
+        issues.append(f"Pi telemetry extension: {exc}")
+        return
+
+    if status.state == pi_extension.NOT_DETECTED:
         rprint("  [dim]Pi not detected[/dim]")
         return
-
-    try:
-        expected = _pi_extension_source()
-    except OSError as exc:
-        issues.append(str(exc))
-        return
-    extension_path = _pi_extension_path()
-    try:
-        current = extension_path.read_text() if extension_path.exists() else None
-    except OSError as exc:
-        issues.append(f"{extension_path}: {exc}")
-        return
-
-    settings_path = pi_dir / "settings.json"
-    legacy_registered = False
-    if settings_path.exists():
-        settings = _load_json(settings_path)
-        if settings is None:
-            issues.append(f"{settings_path}: not valid JSON.")
-            return
-        legacy_registered = any(_is_legacy_pi_package(package) for package in settings.get("packages", []))
-
-    if current != expected:
-        state = "stale" if current is not None else "not installed"
-        warnings.append(f"Observal Pi extension is {state}. Doctor can install {extension_path} directly.")
-    elif legacy_registered:
-        warnings.append("Legacy npm:observal-pi registration remains. Doctor can remove it.")
+    if status.message:
+        warnings.append(status.message)
 
 
 def _check_cursor(issues: list, warnings: list):
@@ -947,30 +908,19 @@ def _cleanup_kiro(dry_run: bool) -> bool:
 
 
 def _cleanup_pi(dry_run: bool) -> bool:
+    """Remove an Observal-managed local Pi extension install.
+
+    Never touches an npm:observal-pi registration (that's the user's own
+    choice, not something Observal installed) and never touches a local
+    file that isn't Observal-managed.
+    """
     rprint("[cyan]Pi[/cyan]")
-    extension_path = _pi_extension_path()
-    settings_path = Path.home() / ".pi" / "agent" / "settings.json"
-    changed = extension_path.exists()
-    if extension_path.exists():
+    changed = pi_extension.remove(dry_run=dry_run)
+    if changed:
         verb = "Would remove" if dry_run else "Removed"
-        rprint(f"  {verb} {esc(extension_path)}")
-        if not dry_run:
-            extension_path.unlink()
-
-    if settings_path.exists():
-        settings = _read_json_object(settings_path)
-        packages = settings.get("packages", [])
-        cleaned = [package for package in packages if not _is_legacy_pi_package(package)]
-        if cleaned != packages:
-            changed = True
-            verb = "Would remove" if dry_run else "Removed"
-            rprint(f"  {verb} legacy npm:observal-pi package registration")
-            if not dry_run:
-                settings["packages"] = cleaned
-                _atomic_write(settings_path, json.dumps(settings, indent=2) + "\n")
-
-    if not changed:
-        rprint("  [dim]No Observal Pi extension found[/dim]")
+        rprint(f"  {verb} {esc(pi_extension.extension_path())}")
+    else:
+        rprint("  [dim]No Observal-managed Pi extension found[/dim]")
     return changed
 
 
@@ -1420,49 +1370,39 @@ def _patch_antigravity(dry_run: bool) -> bool:
     return True
 
 
+_PI_ACTION_VERBS = {
+    "install": ("Would install", "Installed"),
+    "refresh": ("Would update", "Updated"),
+    "adopt": ("Would record install metadata for", "Recorded install metadata for"),
+}
+
+
 def _patch_pi(dry_run: bool) -> bool:
-    """Install the bundled telemetry extension directly into Pi's user directory."""
+    """Install or refresh the bundled telemetry extension, when npm isn't configured."""
     optic.trace("dry_run={}", dry_run)
     rprint("[cyan]Pi - session telemetry extension[/cyan]")
 
-    pi_dir = Path.home() / ".pi" / "agent"
-    if not pi_dir.is_dir():
-        rprint("  [dim]No ~/.pi/agent/ directory - skipping[/dim]")
+    changed, action = pi_extension.install_or_refresh(dry_run=dry_run)
+
+    if not changed:
+        status = pi_extension.check_status()
+        if status.state == pi_extension.NOT_DETECTED:
+            rprint("  [dim]No ~/.pi/agent/ directory - skipping[/dim]")
+        elif status.state in (pi_extension.NPM_CURRENT, pi_extension.NPM_UNPINNED, pi_extension.NPM_STALE):
+            rprint("  [dim]npm:observal-pi is configured - leaving the local extension untouched[/dim]")
+            if status.message:
+                rprint(f"  [yellow]{esc(status.message)}[/yellow]")
+        elif status.state == pi_extension.UNMANAGED:
+            rprint(f"  [yellow]{esc(status.message)}[/yellow]")
+        else:
+            rprint("  [dim]Already up to date[/dim]")
         return False
 
-    source = _pi_extension_source()
-    extension_path = _pi_extension_path()
-    current = extension_path.read_text() if extension_path.exists() else None
-    extension_changed = current != source
-
-    settings_path = pi_dir / "settings.json"
-    settings: dict = {}
-    if settings_path.exists():
-        settings = _read_json_object(settings_path)
-    packages = settings.get("packages", [])
-    cleaned_packages = [package for package in packages if not _is_legacy_pi_package(package)]
-    settings_changed = cleaned_packages != packages
-
-    if not extension_changed and not settings_changed:
-        rprint("  [dim]Already up to date[/dim]")
-        return False
-
-    if extension_changed:
-        verb = "Would install" if current is None else "Would update"
-        if not dry_run:
-            extension_path.parent.mkdir(parents=True, exist_ok=True)
-            _atomic_write(extension_path, source)
-            verb = "Installed" if current is None else "Updated"
-        rprint(f"  {verb} {esc(extension_path)}")
-
-    if settings_changed:
-        if not dry_run:
-            settings["packages"] = cleaned_packages
-            _atomic_write(settings_path, json.dumps(settings, indent=2) + "\n")
-        verb = "Would remove" if dry_run else "Removed"
-        rprint(f"  {verb} legacy npm:observal-pi package registration")
-
-    rprint("  [dim]Restart pi or run /reload to activate[/dim]")
+    would_verb, done_verb = _PI_ACTION_VERBS[action]
+    verb = would_verb if dry_run else done_verb
+    rprint(f"  {verb} {esc(pi_extension.extension_path())}")
+    if not dry_run and action != "adopt":
+        rprint("  [dim]Restart pi or run /reload to activate[/dim]")
     return True
 
 

--- a/observal_cli/harness/pi.py
+++ b/observal_cli/harness/pi.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Pi harness adapter for scanning and hook detection."""
@@ -85,8 +86,12 @@ class PiAdapter(BaseAdapter):
         )
 
     def detect_hooks(self, config_dir: Path) -> str:
-        """Check for the user-global Observal TypeScript extension."""
-        return "installed" if (config_dir / "extensions" / "observal.ts").is_file() else "missing"
+        """Check for the local Observal extension file or a configured npm:observal-pi package."""
+        from observal_cli.pi_extension import is_npm_configured
+
+        if (config_dir / "extensions" / "observal.ts").is_file() or is_npm_configured(config_dir):
+            return "installed"
+        return "missing"
 
     # ── Private helpers ───────────────────────────────────────
 

--- a/observal_cli/pi_extension.py
+++ b/observal_cli/pi_extension.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install/version-check logic for the bundled Pi telemetry extension.
+
+Two installation modes coexist:
+  - npm: the user has `npm:observal-pi[@version]` configured in
+    ~/.pi/agent/settings.json. Observal never writes to this path; it only
+    reports when a pinned version is older than the installed CLI.
+  - local: Observal writes the canonical extension straight to
+    ~/.pi/agent/extensions/observal.ts, tracked by an adjacent
+    .observal-extension.json manifest recording the CLI version it was
+    installed from. A file at that path with no matching manifest is
+    treated as unmanaged and never overwritten.
+
+npm takes priority: if it's configured (even if not yet downloaded by Pi),
+the local path is left untouched entirely.
+
+Shared by `observal doctor` (interactive check/patch/cleanup) and the
+automatic post-login install in cmd_auth.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from packaging.version import InvalidVersion, Version
+
+from observal_cli.shared.utils import load_jsonc
+from observal_cli.version_check import get_current_version
+
+_NPM_SOURCE = "npm:observal-pi"
+
+NOT_DETECTED = "not_detected"
+NOT_INSTALLED = "not_installed"
+CURRENT = "current"
+STALE = "stale"
+NEWER = "newer"
+UNMANAGED = "unmanaged"
+NPM_CURRENT = "npm_current"
+NPM_STALE = "npm_stale"
+NPM_UNPINNED = "npm_unpinned"
+
+
+@dataclass(frozen=True)
+class PiExtensionStatus:
+    state: str
+    message: str | None = None
+    action: str | None = None  # None | "install" | "refresh" | "adopt"
+
+
+def pi_agent_dir(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".pi" / "agent"
+
+
+def extension_path(home: Path | None = None) -> Path:
+    return pi_agent_dir(home) / "extensions" / "observal.ts"
+
+
+def manifest_path(home: Path | None = None) -> Path:
+    return pi_agent_dir(home) / "extensions" / ".observal-extension.json"
+
+
+def settings_path(home: Path | None = None) -> Path:
+    return pi_agent_dir(home) / "settings.json"
+
+
+def extension_source() -> str:
+    """Read the canonical extension source: bundled wheel copy, or dev source tree."""
+    bundled = Path(__file__).parent / "_bundled" / "observal.ts"
+    source_tree = Path(__file__).parents[1] / "packages" / "pi-extension" / "extensions" / "observal.ts"
+    for path in (bundled, source_tree):
+        if path.exists():
+            return path.read_text()
+    raise FileNotFoundError("Bundled Pi telemetry extension is missing")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    temporary: Path | None = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing_mode = path.stat().st_mode if path.exists() else None
+        with NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False) as file:
+            temporary = Path(file.name)
+            file.write(content)
+        if existing_mode is not None:
+            os.chmod(temporary, existing_mode)
+        temporary.replace(path)
+    except OSError:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise
+
+
+def _npm_entry(settings: dict) -> str | None:
+    for package in settings.get("packages", []):
+        if isinstance(package, str):
+            source = package
+        elif isinstance(package, dict):
+            source = package.get("source", "")
+        else:
+            continue
+        if source == _NPM_SOURCE or source.startswith(f"{_NPM_SOURCE}@"):
+            return source
+    return None
+
+
+def is_npm_configured(pi_dir: Path) -> bool:
+    """Whether npm:observal-pi is registered in this Pi agent dir's settings.json.
+
+    Swallows unreadable/invalid settings rather than raising: used by hook
+    detection, where a best-effort boolean is all that's needed.
+    """
+    settings_file = pi_dir / "settings.json"
+    if not settings_file.exists():
+        return False
+    try:
+        settings = load_jsonc(settings_file)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return False
+    return isinstance(settings, dict) and _npm_entry(settings) is not None
+
+
+def _npm_pinned_version(source: str) -> str | None:
+    _, _, version = source.partition(f"{_NPM_SOURCE}@")
+    return version or None
+
+
+def _parse_version(value: str) -> Version | None:
+    try:
+        return Version(value)
+    except InvalidVersion:
+        return None
+
+
+def _read_manifest(home: Path | None = None) -> dict | None:
+    path = manifest_path(home)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def check_status(home: Path | None = None) -> PiExtensionStatus:
+    """Determine the current install state.
+
+    Raises OSError/ValueError if settings.json or the installed extension
+    file exist but can't be read/parsed — callers decide how to surface that.
+    """
+    pi_dir = pi_agent_dir(home)
+    if not pi_dir.exists():
+        return PiExtensionStatus(NOT_DETECTED)
+
+    settings_file = settings_path(home)
+    settings: dict = {}
+    if settings_file.exists():
+        settings = load_jsonc(settings_file)
+        if not isinstance(settings, dict):
+            raise ValueError(f"{settings_file}: must contain a JSON object")
+
+    npm_source = _npm_entry(settings)
+    if npm_source is not None:
+        pinned = _npm_pinned_version(npm_source)
+        pinned_version = _parse_version(pinned) if pinned else None
+        current_version = _parse_version(get_current_version())
+        if pinned_version is not None and current_version is not None and pinned_version < current_version:
+            return PiExtensionStatus(
+                NPM_STALE,
+                f"Configured {npm_source} is older than the installed Observal CLI "
+                f"({get_current_version()}). Run `pi update npm:observal-pi` to refresh the extension.",
+            )
+        return PiExtensionStatus(NPM_CURRENT if pinned_version is not None else NPM_UNPINNED)
+
+    # Read the bundled source eagerly (not just when we're about to install)
+    # so a broken/missing package bundle is surfaced by `doctor check`, not
+    # only discovered later when a patch/install is actually attempted.
+    expected = extension_source()
+
+    path = extension_path(home)
+    if not path.exists():
+        return PiExtensionStatus(
+            NOT_INSTALLED,
+            f"Observal Pi extension is not installed. Doctor can install {path}.",
+            action="install",
+        )
+
+    try:
+        installed = path.read_text()
+    except OSError as exc:
+        raise OSError(f"{path}: {exc}") from exc
+
+    manifest = _read_manifest(home)
+    if manifest is not None and manifest.get("managed") is True and isinstance(manifest.get("version"), str):
+        manifest_version = _parse_version(manifest["version"])
+        current_version = _parse_version(get_current_version())
+        if manifest_version is not None and current_version is not None:
+            if manifest_version < current_version:
+                return PiExtensionStatus(
+                    STALE,
+                    f"Observal Pi extension is stale ({manifest['version']} < {get_current_version()}). "
+                    f"Doctor can refresh {path}.",
+                    action="refresh",
+                )
+            if manifest_version > current_version:
+                return PiExtensionStatus(NEWER)
+            return PiExtensionStatus(CURRENT)
+
+    # No trustworthy manifest. Adopt silently if the content already matches
+    # what we'd install (covers pre-manifest installs from before this
+    # feature existed); otherwise this is a foreign file we must not touch.
+    if installed == expected:
+        return PiExtensionStatus(CURRENT, action="adopt")
+    return PiExtensionStatus(
+        UNMANAGED,
+        f"{path} exists but is not managed by Observal. Remove it (or move it aside) and "
+        "re-run `observal doctor patch --harness pi` to let Observal manage the Pi extension, "
+        "or leave it as-is to keep using it unmanaged.",
+    )
+
+
+def install_or_refresh(*, dry_run: bool, home: Path | None = None) -> tuple[bool, str | None]:
+    """Perform the recommended action, if any.
+
+    Returns (changed, action) where action is "install" | "refresh" | "adopt",
+    matching PiExtensionStatus.action, or (False, None) if nothing to do.
+    """
+    status = check_status(home)
+    if status.action is None:
+        return False, None
+    if dry_run:
+        return True, status.action
+    if status.action != "adopt":
+        _atomic_write(extension_path(home), extension_source())
+    _atomic_write(
+        manifest_path(home),
+        json.dumps({"managed": True, "version": get_current_version()}, indent=2) + "\n",
+    )
+    return True, status.action
+
+
+def remove(*, dry_run: bool, home: Path | None = None) -> bool:
+    """Remove an Observal-managed local install. Never touches npm config or unmanaged files."""
+    status = check_status(home)
+    if status.state not in (CURRENT, STALE, NEWER):
+        return False
+    if not dry_run:
+        extension_path(home).unlink(missing_ok=True)
+        manifest_path(home).unlink(missing_ok=True)
+    return True

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 0xSHSH <156781261+0xSHSH@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Behavioral coverage for the doctor CLI commands and untested state branches."""
@@ -19,7 +20,13 @@ import pytest
 from typer.testing import CliRunner
 
 import observal_cli.cmd_doctor as doctor_module
+from observal_cli import pi_extension
 from observal_cli.harness.protocol import NotSupportedError
+
+# Fixed regardless of what observal-cli version this test environment actually
+# resolves (which varies across invocation contexts) - keeps Pi stale/current/newer
+# comparisons deterministic.
+CLI_VERSION = "2.0.0"
 
 _ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 _DIAGNOSTIC_CHECKS = (
@@ -61,6 +68,7 @@ def isolated_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SimpleN
     monkeypatch.setattr(httpx, "get", network)
     monkeypatch.setattr(subprocess, "run", process)
     monkeypatch.setattr(doctor_module.typer, "confirm", prompt)
+    monkeypatch.setattr(pi_extension, "get_current_version", lambda: CLI_VERSION)
     return SimpleNamespace(network=network, process=process, prompt=prompt)
 
 
@@ -338,14 +346,10 @@ class TestHarnessDiagnosisState:
 
         assert warnings == []
 
-    def test_pi_current_extension_reports_legacy_dict_registration(self, tmp_path: Path):
-        source = doctor_module._pi_extension_source()
-        extension = tmp_path / ".pi" / "agent" / "extensions" / "observal.ts"
-        extension.parent.mkdir(parents=True)
-        extension.write_text(source, encoding="utf-8")
+    def test_pi_recognizes_dict_form_npm_entry_and_ignores_malformed_entries(self, tmp_path: Path):
         _write_json(
             tmp_path / ".pi" / "agent" / "settings.json",
-            {"packages": [{"source": "npm:observal-pi@1.0.0"}, 7]},
+            {"packages": [{"source": f"npm:observal-pi@{CLI_VERSION}"}, 7]},
         )
         issues: list[str] = []
         warnings: list[str] = []
@@ -353,19 +357,19 @@ class TestHarnessDiagnosisState:
         doctor_module._check_pi(issues, warnings)
 
         assert issues == []
-        assert warnings == ["Legacy npm:observal-pi registration remains. Doctor can remove it."]
-        assert doctor_module._is_legacy_pi_package(7) is False
+        assert warnings == []  # npm configured and current: no local install, nothing to report
+        assert not (tmp_path / ".pi" / "agent" / "extensions" / "observal.ts").exists()
 
     def test_pi_source_and_settings_failures_are_issues(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         (tmp_path / ".pi" / "agent").mkdir(parents=True)
-        monkeypatch.setattr(doctor_module, "_pi_extension_source", MagicMock(side_effect=OSError("source missing")))
+        monkeypatch.setattr(pi_extension, "extension_source", MagicMock(side_effect=OSError("source missing")))
         issues: list[str] = []
 
         doctor_module._check_pi(issues, [])
 
-        assert issues == ["source missing"]
+        assert issues == ["Pi telemetry extension: source missing"]
 
-        monkeypatch.setattr(doctor_module, "_pi_extension_source", lambda: "source")
+        monkeypatch.setattr(pi_extension, "extension_source", lambda: "source")
         settings = tmp_path / ".pi" / "agent" / "settings.json"
         settings.write_text("invalid", encoding="utf-8")
         issues = []
@@ -377,10 +381,10 @@ class TestHarnessDiagnosisState:
     def test_pi_extension_source_fails_when_no_bundled_or_source_file_exists(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        monkeypatch.setattr(doctor_module, "__file__", str(tmp_path / "pkg" / "observal_cli" / "cmd_doctor.py"))
+        monkeypatch.setattr(pi_extension, "__file__", str(tmp_path / "pkg" / "observal_cli" / "pi_extension.py"))
 
         with pytest.raises(FileNotFoundError, match="Bundled Pi telemetry extension is missing"):
-            doctor_module._pi_extension_source()
+            pi_extension.extension_source()
 
     @pytest.mark.parametrize(
         ("harness", "relative_path", "checker", "expected"),
@@ -880,26 +884,34 @@ class TestPatchStateEdges:
         pi_dir.mkdir(parents=True)
         settings = pi_dir / "settings.json"
         settings.write_text("invalid", encoding="utf-8")
-        monkeypatch.setattr(doctor_module, "_pi_extension_source", lambda: "source")
 
         with pytest.raises(json.JSONDecodeError):
             doctor_module._patch_pi(dry_run=False)
         assert not (pi_dir / "extensions" / "observal.ts").exists()
 
-    def test_pi_dry_run_preserves_legacy_settings_and_extension_state(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    def test_pi_dry_run_leaves_npm_configured_settings_untouched(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ):
         settings = tmp_path / ".pi" / "agent" / "settings.json"
         _write_json(settings, {"packages": ["npm:observal-pi"]})
-        monkeypatch.setattr(doctor_module, "_pi_extension_source", lambda: "source")
         before = settings.read_text(encoding="utf-8")
 
-        assert doctor_module._patch_pi(dry_run=True) is True
+        assert doctor_module._patch_pi(dry_run=True) is False
         assert settings.read_text(encoding="utf-8") == before
         assert not (tmp_path / ".pi" / "agent" / "extensions" / "observal.ts").exists()
         output = _plain(capsys.readouterr().out)
+        assert "npm:observal-pi is configured" in output
+
+    def test_pi_dry_run_previews_local_install_without_writing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        (tmp_path / ".pi" / "agent").mkdir(parents=True)
+
+        assert doctor_module._patch_pi(dry_run=True) is True
+        assert not (tmp_path / ".pi" / "agent" / "extensions" / "observal.ts").exists()
+        assert not (tmp_path / ".pi" / "agent" / "extensions" / ".observal-extension.json").exists()
+        output = _plain(capsys.readouterr().out)
         assert "Would install" in output
-        assert "Would remove legacy npm:observal-pi" in output
 
     def test_codex_dry_run_on_missing_state_does_not_create_directory(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_cli_harness_adapters.py
+++ b/tests/test_cli_harness_adapters.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the CLI-side harness adapter protocol and registry."""
@@ -99,6 +100,22 @@ class TestAdapterRegistry:
 
         assert plan.target == tmp_path / ".pi/agent/skills/observal/SKILL.md"
         assert plan.reuse_candidates == (tmp_path / ".agents/skills/observal/SKILL.md",)
+
+    def test_pi_detect_hooks_missing_when_neither_install_mode_is_present(self, tmp_path):
+        assert get_adapter("pi").detect_hooks(tmp_path) == "missing"
+
+    def test_pi_detect_hooks_recognizes_local_extension_file(self, tmp_path):
+        extension = tmp_path / "extensions" / "observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("extension", encoding="utf-8")
+
+        assert get_adapter("pi").detect_hooks(tmp_path) == "installed"
+
+    def test_pi_detect_hooks_recognizes_configured_npm_package(self, tmp_path):
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"packages": ["npm:observal-pi"]}), encoding="utf-8")
+
+        assert get_adapter("pi").detect_hooks(tmp_path) == "installed"
 
 
 class TestManagedLayerFiles:

--- a/tests/test_cmd_auth.py
+++ b/tests/test_cmd_auth.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 OpenAI contributors
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Behavioral tests for :mod:`observal_cli.cmd_auth`."""
@@ -1721,15 +1722,18 @@ def test_post_login_setup_installs_skills_snapshots_and_runs_doctor(
     import observal_cli.cmd_doctor as cmd_doctor
 
     install = MagicMock()
+    pi_extension = MagicMock()
     snapshot = MagicMock()
     doctor = MagicMock()
     monkeypatch.setattr(auth, "_install_observal_skill", install)
+    monkeypatch.setattr(auth, "_install_or_check_pi_extension", pi_extension)
     monkeypatch.setattr(auth, "_generate_initial_layer_snapshot", snapshot)
     monkeypatch.setattr(cmd_doctor, "doctor", doctor)
 
     auth._post_login_setup()
 
     install.assert_called_once_with()
+    pi_extension.assert_called_once_with()
     snapshot.assert_called_once_with()
     assert doctor.call_args.kwargs["yes"] is False
     assert doctor.call_args.kwargs["ctx"].invoked_subcommand is None
@@ -1744,6 +1748,7 @@ def test_post_login_setup_contains_doctor_failures(
     import observal_cli.cmd_doctor as cmd_doctor
 
     monkeypatch.setattr(auth, "_install_observal_skill", MagicMock())
+    monkeypatch.setattr(auth, "_install_or_check_pi_extension", MagicMock())
     monkeypatch.setattr(auth, "_generate_initial_layer_snapshot", MagicMock())
     monkeypatch.setattr(cmd_doctor, "doctor", MagicMock(side_effect=error))
 
@@ -1827,6 +1832,89 @@ def test_install_observal_skill_delegates_to_installer(monkeypatch: pytest.Monke
     auth._install_observal_skill()
 
     install.assert_called_once_with()
+
+
+def test_pi_extension_setup_is_silent_when_pi_not_detected(monkeypatch: pytest.MonkeyPatch, printed: list[str]) -> None:
+    import observal_cli.pi_extension as pi_extension
+
+    monkeypatch.setattr(pi_extension, "check_status", lambda: pi_extension.PiExtensionStatus(pi_extension.NOT_DETECTED))
+    install_or_refresh = MagicMock()
+    monkeypatch.setattr(pi_extension, "install_or_refresh", install_or_refresh)
+
+    auth._install_or_check_pi_extension()
+
+    install_or_refresh.assert_not_called()
+    assert printed == []
+
+
+def test_pi_extension_setup_installs_when_missing(monkeypatch: pytest.MonkeyPatch, printed: list[str]) -> None:
+    import observal_cli.pi_extension as pi_extension
+
+    status = pi_extension.PiExtensionStatus(pi_extension.NOT_INSTALLED, "not installed", action="install")
+    monkeypatch.setattr(pi_extension, "check_status", lambda: status)
+    install_or_refresh = MagicMock()
+    monkeypatch.setattr(pi_extension, "install_or_refresh", install_or_refresh)
+
+    auth._install_or_check_pi_extension()
+
+    install_or_refresh.assert_called_once_with(dry_run=False)
+    assert any("Installed the Pi telemetry extension" in message for message in printed)
+
+
+def test_pi_extension_setup_refreshes_and_prompts_reload_when_stale(
+    monkeypatch: pytest.MonkeyPatch, printed: list[str]
+) -> None:
+    import observal_cli.pi_extension as pi_extension
+
+    status = pi_extension.PiExtensionStatus(pi_extension.STALE, "stale", action="refresh")
+    monkeypatch.setattr(pi_extension, "check_status", lambda: status)
+    monkeypatch.setattr(pi_extension, "install_or_refresh", MagicMock())
+
+    auth._install_or_check_pi_extension()
+
+    output = "\n".join(printed)
+    assert "Updated the Pi telemetry extension" in output
+    assert "reload" in output.lower()
+
+
+def test_pi_extension_setup_adopts_silently(monkeypatch: pytest.MonkeyPatch, printed: list[str]) -> None:
+    import observal_cli.pi_extension as pi_extension
+
+    status = pi_extension.PiExtensionStatus(pi_extension.CURRENT, action="adopt")
+    monkeypatch.setattr(pi_extension, "check_status", lambda: status)
+    install_or_refresh = MagicMock()
+    monkeypatch.setattr(pi_extension, "install_or_refresh", install_or_refresh)
+
+    auth._install_or_check_pi_extension()
+
+    install_or_refresh.assert_called_once_with(dry_run=False)
+    assert printed == []
+
+
+def test_pi_extension_setup_reports_stale_npm_without_installing_locally(
+    monkeypatch: pytest.MonkeyPatch, printed: list[str]
+) -> None:
+    import observal_cli.pi_extension as pi_extension
+
+    status = pi_extension.PiExtensionStatus(pi_extension.NPM_STALE, "pi update npm:observal-pi")
+    monkeypatch.setattr(pi_extension, "check_status", lambda: status)
+    install_or_refresh = MagicMock()
+    monkeypatch.setattr(pi_extension, "install_or_refresh", install_or_refresh)
+
+    auth._install_or_check_pi_extension()
+
+    install_or_refresh.assert_not_called()
+    assert any("pi update npm:observal-pi" in message for message in printed)
+
+
+def test_pi_extension_setup_never_blocks_login_on_failure(monkeypatch: pytest.MonkeyPatch, printed: list[str]) -> None:
+    import observal_cli.pi_extension as pi_extension
+
+    monkeypatch.setattr(pi_extension, "check_status", MagicMock(side_effect=OSError("settings.json unreadable")))
+
+    auth._install_or_check_pi_extension()  # must not raise
+
+    assert any("Could not check the Pi telemetry extension" in message for message in printed)
 
 
 def test_run_doctor_patch_uses_isolated_subprocess_environment(

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Annie Chiang <anniechiang.yn@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for observal_cli.cmd_doctor helpers."""
@@ -15,6 +16,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
+from observal_cli import pi_extension
 from observal_cli.cmd_doctor import (
     _check_antigravity,
     _check_claude_code,
@@ -53,6 +55,11 @@ from observal_cli.cmd_doctor import (
 from observal_cli.shared.utils import is_observal_hook_entry, is_observal_matcher_group
 from observal_shared.opencode_plugin_source import OPENCODE_PLUGIN_SOURCE
 
+# Fixed regardless of what observal-cli version this test environment actually
+# resolves (which varies across invocation contexts) - keeps Pi stale/current/newer
+# comparisons deterministic.
+CLI_VERSION = "2.0.0"
+
 
 @pytest.fixture(autouse=True)
 def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -61,6 +68,7 @@ def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr("observal_cli.settings_reconciler.config.save", lambda updates: None)
     monkeypatch.setattr("observal_cli.lockfile.LOCKFILE_PATH", tmp_path / ".observal/lockfile.json")
     monkeypatch.setattr("observal_cli.lockfile._LOCKFILE_LOCK", tmp_path / ".observal/lockfile.lock")
+    monkeypatch.setattr(pi_extension, "get_current_version", lambda: CLI_VERSION)
     return tmp_path
 
 
@@ -138,6 +146,86 @@ class TestChecks:
         _check_pi([], warnings)
 
         assert any("extensions/observal.ts" in warning for warning in warnings)
+
+    def test_pi_is_silent_when_npm_package_is_current(self, tmp_path: Path):
+        write_json(tmp_path / ".pi/agent/settings.json", {"packages": [f"npm:observal-pi@{CLI_VERSION}"]})
+        warnings: list[str] = []
+
+        _check_pi([], warnings)
+
+        assert warnings == []
+        assert not (tmp_path / ".pi/agent/extensions/observal.ts").exists()
+
+    def test_pi_is_silent_when_npm_package_is_unpinned(self, tmp_path: Path):
+        write_json(tmp_path / ".pi/agent/settings.json", {"packages": ["npm:observal-pi"]})
+        warnings: list[str] = []
+
+        _check_pi([], warnings)
+
+        assert warnings == []
+        assert not (tmp_path / ".pi/agent/extensions/observal.ts").exists()
+
+    def test_pi_warns_when_pinned_npm_package_is_stale(self, tmp_path: Path):
+        write_json(tmp_path / ".pi/agent/settings.json", {"packages": ["npm:observal-pi@0.0.1"]})
+        warnings: list[str] = []
+
+        _check_pi([], warnings)
+
+        assert any("pi update npm:observal-pi" in warning for warning in warnings)
+        assert not (tmp_path / ".pi/agent/extensions/observal.ts").exists()
+
+    def test_pi_is_silent_when_local_install_is_current(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text(pi_extension.extension_source(), encoding="utf-8")
+        write_json(
+            tmp_path / ".pi/agent/extensions/.observal-extension.json",
+            {"managed": True, "version": CLI_VERSION},
+        )
+        warnings: list[str] = []
+
+        _check_pi([], warnings)
+
+        assert warnings == []
+
+    def test_pi_warns_when_local_install_is_stale(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("old content", encoding="utf-8")
+        write_json(
+            tmp_path / ".pi/agent/extensions/.observal-extension.json",
+            {"managed": True, "version": "0.0.1"},
+        )
+        warnings: list[str] = []
+
+        _check_pi([], warnings)
+
+        assert any("stale" in warning for warning in warnings)
+
+    def test_pi_is_silent_when_local_install_is_newer(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("future content", encoding="utf-8")
+        write_json(
+            tmp_path / ".pi/agent/extensions/.observal-extension.json",
+            {"managed": True, "version": "9999.0.0"},
+        )
+        warnings: list[str] = []
+
+        _check_pi([], warnings)
+
+        assert warnings == []
+        assert extension.read_text(encoding="utf-8") == "future content"
+
+    def test_pi_warns_of_conflict_with_unmanaged_local_file(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("hand-written extension", encoding="utf-8")
+        warnings: list[str] = []
+
+        _check_pi([], warnings)
+
+        assert any("not managed by Observal" in warning for warning in warnings)
 
     def test_cursor_warns_when_hooks_file_missing(self, tmp_path: Path):
         (tmp_path / ".cursor").mkdir()
@@ -328,16 +416,59 @@ class TestPatchFunctions:
         assert any("hooks.session_push --harness cursor" in command for command in commands)
         assert _patch_cursor(dry_run=False) is False
 
-    def test_patch_pi_installs_direct_extension_and_removes_legacy_package(self, tmp_path: Path):
-        from observal_cli.cmd_doctor import _pi_extension_source
-
-        settings = tmp_path / ".pi/agent/settings.json"
-        write_json(settings, {"packages": ["npm:@observal/pi-insights", "npm:observal-pi"]})
+    def test_patch_pi_installs_local_extension_and_manifest(self, tmp_path: Path):
+        (tmp_path / ".pi/agent").mkdir(parents=True)
 
         assert _patch_pi(dry_run=False) is True
         extension = tmp_path / ".pi/agent/extensions/observal.ts"
-        assert extension.read_text() == _pi_extension_source()
-        assert read_json(settings)["packages"] == ["npm:@observal/pi-insights"]
+        manifest = tmp_path / ".pi/agent/extensions/.observal-extension.json"
+        assert extension.read_text() == pi_extension.extension_source()
+        assert read_json(manifest) == {"managed": True, "version": CLI_VERSION}
+        assert _patch_pi(dry_run=False) is False
+
+    def test_patch_pi_skips_local_install_when_npm_is_configured(self, tmp_path: Path):
+        settings = tmp_path / ".pi/agent/settings.json"
+        write_json(settings, {"packages": ["npm:@observal/pi-insights", "npm:observal-pi"]})
+
+        assert _patch_pi(dry_run=False) is False
+
+        assert not (tmp_path / ".pi/agent/extensions/observal.ts").exists()
+        assert read_json(settings)["packages"] == ["npm:@observal/pi-insights", "npm:observal-pi"]
+
+    def test_patch_pi_refreshes_a_stale_managed_install(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("old content", encoding="utf-8")
+        write_json(
+            tmp_path / ".pi/agent/extensions/.observal-extension.json",
+            {"managed": True, "version": "0.0.1"},
+        )
+
+        assert _patch_pi(dry_run=False) is True
+
+        assert extension.read_text() == pi_extension.extension_source()
+        manifest = read_json(tmp_path / ".pi/agent/extensions/.observal-extension.json")
+        assert manifest["version"] == CLI_VERSION
+
+    def test_patch_pi_never_overwrites_an_unmanaged_file(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("hand-written extension", encoding="utf-8")
+
+        assert _patch_pi(dry_run=False) is False
+
+        assert extension.read_text() == "hand-written extension"
+        assert not (tmp_path / ".pi/agent/extensions/.observal-extension.json").exists()
+
+    def test_patch_pi_adopts_a_pre_manifest_install_without_rewriting_content(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text(pi_extension.extension_source(), encoding="utf-8")
+
+        assert _patch_pi(dry_run=False) is True
+
+        manifest = read_json(tmp_path / ".pi/agent/extensions/.observal-extension.json")
+        assert manifest == {"managed": True, "version": CLI_VERSION}
         assert _patch_pi(dry_run=False) is False
 
     def test_patch_codex_writes_hooks_and_enables_flag(self, tmp_path: Path):
@@ -477,16 +608,31 @@ class TestCleanupFunctions:
 
         assert read_json(agent_path)["hooks"]["userPromptSubmit"] == [foreign]
 
-    def test_cleanup_pi_removes_direct_extension_and_legacy_package(self, tmp_path: Path):
+    def test_cleanup_pi_removes_a_managed_install(self, tmp_path: Path):
         extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        manifest = tmp_path / ".pi/agent/extensions/.observal-extension.json"
         extension.parent.mkdir(parents=True)
-        extension.write_text("extension")
-        settings = tmp_path / ".pi/agent/settings.json"
-        write_json(settings, {"packages": ["npm:observal-pi", "npm:@observal/pi-insights"]})
+        extension.write_text(pi_extension.extension_source(), encoding="utf-8")
+        write_json(manifest, {"managed": True, "version": CLI_VERSION})
 
         assert _cleanup_pi(dry_run=False) is True
         assert not extension.exists()
-        assert read_json(settings)["packages"] == ["npm:@observal/pi-insights"]
+        assert not manifest.exists()
+
+    def test_cleanup_pi_leaves_npm_registration_untouched(self, tmp_path: Path):
+        settings = tmp_path / ".pi/agent/settings.json"
+        write_json(settings, {"packages": ["npm:observal-pi", "npm:@observal/pi-insights"]})
+
+        assert _cleanup_pi(dry_run=False) is False
+        assert read_json(settings)["packages"] == ["npm:observal-pi", "npm:@observal/pi-insights"]
+
+    def test_cleanup_pi_leaves_an_unmanaged_file_untouched(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("hand-written extension", encoding="utf-8")
+
+        assert _cleanup_pi(dry_run=False) is False
+        assert extension.read_text() == "hand-written extension"
 
     def test_cleanup_cursor_preserves_foreign_hooks(self, tmp_path: Path):
         hooks_path = tmp_path / ".cursor/hooks.json"

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for observal_cli.pi_extension: the npm/local install state machine."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from observal_cli import pi_extension
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Fixed regardless of what observal-cli version this test environment actually
+# resolves (which varies across invocation contexts) - keeps stale/current/newer
+# comparisons deterministic.
+CLI_VERSION = "2.0.0"
+
+
+@pytest.fixture(autouse=True)
+def fixed_cli_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pi_extension, "get_current_version", lambda: CLI_VERSION)
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestCheckStatus:
+    def test_not_detected_when_pi_agent_dir_is_missing(self, tmp_path: Path):
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NOT_DETECTED
+        assert status.action is None
+
+    def test_not_installed_when_pi_present_and_extension_absent(self, tmp_path: Path):
+        (tmp_path / ".pi/agent").mkdir(parents=True)
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NOT_INSTALLED
+        assert status.action == "install"
+
+    def test_npm_string_entry_pinned_and_current_skips_local(self, tmp_path: Path):
+        write_json(
+            tmp_path / ".pi/agent/settings.json",
+            {"packages": [f"npm:observal-pi@{CLI_VERSION}"]},
+        )
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NPM_CURRENT
+        assert status.action is None
+
+    def test_npm_dict_entry_is_recognized(self, tmp_path: Path):
+        write_json(
+            tmp_path / ".pi/agent/settings.json",
+            {"packages": [{"source": f"npm:observal-pi@{CLI_VERSION}"}]},
+        )
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NPM_CURRENT
+
+    def test_npm_unpinned_entry_is_not_flagged_stale(self, tmp_path: Path):
+        write_json(tmp_path / ".pi/agent/settings.json", {"packages": ["npm:observal-pi"]})
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NPM_UNPINNED
+        assert status.message is None
+
+    def test_npm_pinned_older_than_cli_is_stale(self, tmp_path: Path):
+        write_json(tmp_path / ".pi/agent/settings.json", {"packages": ["npm:observal-pi@0.0.1"]})
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NPM_STALE
+        assert "pi update npm:observal-pi" in status.message
+        assert status.action is None  # never installs locally, even though stale
+
+    def test_unrelated_npm_packages_do_not_trigger_npm_mode(self, tmp_path: Path):
+        (tmp_path / ".pi/agent").mkdir(parents=True)
+        write_json(tmp_path / ".pi/agent/settings.json", {"packages": ["npm:@observal/pi-insights"]})
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NOT_INSTALLED
+
+    def test_local_adopts_pre_manifest_install_when_content_matches(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text(pi_extension.extension_source(), encoding="utf-8")
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.CURRENT
+        assert status.action == "adopt"
+
+    def test_local_flags_conflict_when_content_differs_and_no_manifest(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("someone else's extension", encoding="utf-8")
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.UNMANAGED
+        assert status.action is None
+        assert "not managed by Observal" in status.message
+
+    def test_local_manifest_stale_reports_both_versions(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("old", encoding="utf-8")
+        write_json(tmp_path / ".pi/agent/extensions/.observal-extension.json", {"managed": True, "version": "0.0.1"})
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.STALE
+        assert status.action == "refresh"
+        assert "0.0.1" in status.message
+        assert CLI_VERSION in status.message
+
+    def test_local_manifest_newer_is_not_downgraded(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("from the future", encoding="utf-8")
+        write_json(tmp_path / ".pi/agent/extensions/.observal-extension.json", {"managed": True, "version": "9999.0.0"})
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.NEWER
+        assert status.action is None
+
+    def test_unmanaged_flag_false_in_manifest_is_treated_as_untrusted(self, tmp_path: Path):
+        extension = tmp_path / ".pi/agent/extensions/observal.ts"
+        extension.parent.mkdir(parents=True)
+        extension.write_text("hand written", encoding="utf-8")
+        write_json(tmp_path / ".pi/agent/extensions/.observal-extension.json", {"managed": False, "version": "1.0.0"})
+
+        status = pi_extension.check_status(home=tmp_path)
+
+        assert status.state == pi_extension.UNMANAGED
+
+    def test_invalid_settings_json_raises(self, tmp_path: Path):
+        settings = tmp_path / ".pi/agent/settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text("[]", encoding="utf-8")  # valid JSON, not an object
+
+        with pytest.raises(ValueError):
+            pi_extension.check_status(home=tmp_path)
+
+
+class TestInstallOrRefresh:
+    def test_creates_parent_directories_on_first_install(self, tmp_path: Path):
+        (tmp_path / ".pi/agent").mkdir(parents=True)
+
+        changed, action = pi_extension.install_or_refresh(dry_run=False, home=tmp_path)
+
+        assert changed is True
+        assert action == "install"
+        assert pi_extension.extension_path(tmp_path).read_text() == pi_extension.extension_source()
+        assert read_json(pi_extension.manifest_path(tmp_path)) == {
+            "managed": True,
+            "version": CLI_VERSION,
+        }
+
+    def test_dry_run_reports_without_writing(self, tmp_path: Path):
+        (tmp_path / ".pi/agent").mkdir(parents=True)
+
+        changed, action = pi_extension.install_or_refresh(dry_run=True, home=tmp_path)
+
+        assert changed is True
+        assert action == "install"
+        assert not pi_extension.extension_path(tmp_path).exists()
+
+    def test_noop_when_npm_is_configured(self, tmp_path: Path):
+        write_json(tmp_path / ".pi/agent/settings.json", {"packages": ["npm:observal-pi"]})
+
+        changed, action = pi_extension.install_or_refresh(dry_run=False, home=tmp_path)
+
+        assert (changed, action) == (False, None)
+        assert not pi_extension.extension_path(tmp_path).exists()
+
+    def test_noop_when_file_is_unmanaged(self, tmp_path: Path):
+        extension = pi_extension.extension_path(tmp_path)
+        extension.parent.mkdir(parents=True)
+        extension.write_text("do not touch", encoding="utf-8")
+
+        changed, action = pi_extension.install_or_refresh(dry_run=False, home=tmp_path)
+
+        assert (changed, action) == (False, None)
+        assert extension.read_text() == "do not touch"
+
+    def test_adopt_writes_manifest_without_changing_extension_bytes(self, tmp_path: Path):
+        extension = pi_extension.extension_path(tmp_path)
+        extension.parent.mkdir(parents=True)
+        source = pi_extension.extension_source()
+        extension.write_text(source, encoding="utf-8")
+
+        changed, action = pi_extension.install_or_refresh(dry_run=False, home=tmp_path)
+
+        assert (changed, action) == (True, "adopt")
+        assert extension.read_text() == source
+        assert read_json(pi_extension.manifest_path(tmp_path))["version"] == CLI_VERSION
+
+
+class TestRemove:
+    @pytest.mark.parametrize(
+        "manifest_version",
+        ["0.0.1", CLI_VERSION, "9999.0.0"],
+        ids=["stale", "current", "newer"],
+    )
+    def test_removes_any_managed_install_regardless_of_version(self, tmp_path: Path, manifest_version: str):
+        extension = pi_extension.extension_path(tmp_path)
+        extension.parent.mkdir(parents=True)
+        extension.write_text("content", encoding="utf-8")
+        write_json(pi_extension.manifest_path(tmp_path), {"managed": True, "version": manifest_version})
+
+        assert pi_extension.remove(dry_run=False, home=tmp_path) is True
+        assert not extension.exists()
+        assert not pi_extension.manifest_path(tmp_path).exists()
+
+    def test_leaves_npm_configuration_alone(self, tmp_path: Path):
+        settings = tmp_path / ".pi/agent/settings.json"
+        write_json(settings, {"packages": ["npm:observal-pi"]})
+
+        assert pi_extension.remove(dry_run=False, home=tmp_path) is False
+        assert read_json(settings)["packages"] == ["npm:observal-pi"]
+
+    def test_leaves_unmanaged_file_alone(self, tmp_path: Path):
+        extension = pi_extension.extension_path(tmp_path)
+        extension.parent.mkdir(parents=True)
+        extension.write_text("not ours", encoding="utf-8")
+
+        assert pi_extension.remove(dry_run=False, home=tmp_path) is False
+        assert extension.exists()
+
+    def test_dry_run_reports_without_removing(self, tmp_path: Path):
+        extension = pi_extension.extension_path(tmp_path)
+        extension.parent.mkdir(parents=True)
+        extension.write_text(pi_extension.extension_source(), encoding="utf-8")
+        write_json(pi_extension.manifest_path(tmp_path), {"managed": True, "version": CLI_VERSION})
+
+        assert pi_extension.remove(dry_run=True, home=tmp_path) is True
+        assert extension.exists()
+
+
+class TestIsNpmConfigured:
+    def test_false_when_settings_file_is_absent(self, tmp_path: Path):
+        assert pi_extension.is_npm_configured(tmp_path) is False
+
+    def test_true_for_string_and_dict_entries(self, tmp_path: Path):
+        write_json(tmp_path / "settings.json", {"packages": [{"source": "npm:observal-pi@1.0.0"}]})
+        assert pi_extension.is_npm_configured(tmp_path) is True
+
+    def test_false_for_unrelated_packages(self, tmp_path: Path):
+        write_json(tmp_path / "settings.json", {"packages": ["npm:@observal/pi-insights"]})
+        assert pi_extension.is_npm_configured(tmp_path) is False
+
+    def test_false_when_settings_json_is_invalid(self, tmp_path: Path):
+        settings = tmp_path / "settings.json"
+        settings.write_text("{ not json", encoding="utf-8")
+        assert pi_extension.is_npm_configured(tmp_path) is False


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

Pi telemetry currently depends on `npm:observal-pi` being manually configured in
`~/.pi/agent/settings.json`. Users who skip that step get no telemetry at all, and
`observal doctor` only reports the gap without offering a fix. There was also no way
to tell whether an existing npm or locally-managed installation had fallen behind the
current Observal CLI release.

## Fixes

* Fixes #1602

## Approach

Bundles the canonical Pi extension source (`packages/pi-extension/extensions/observal.ts`)
into the CLI wheel and installs/checks it automatically:

- **npm configured** (`npm:observal-pi[@version]` present in `settings.json`, downloaded
  or not) → left untouched entirely. If a pinned version is older than the installed CLI,
  print an actionable `pi update npm:observal-pi` reminder; unpinned entries are silently
  trusted since there's no reliable way to resolve their actual version without shelling
  out to npm.
- **npm not configured** → atomically install the bundled extension to
  `~/.pi/agent/extensions/observal.ts`, tracked by an adjacent
  `.observal-extension.json` manifest recording the CLI version it was installed from.
  A later CLI upgrade refreshes both files atomically and prints a reload reminder; a
  locally newer install is left alone (never downgraded).
- A file at that path with no matching manifest is treated as **unmanaged** and never
  overwritten or removed — the conflict is reported with manual-resolution instructions
  instead.

Install/check logic lives in a new shared module, `observal_cli/pi_extension.py`, used by:
- `observal_cli/cmd_doctor.py` — `_check_pi`/`_patch_pi`/`_cleanup_pi` now delegate to it
  (previously these treated any npm registration as legacy cruft to strip, which is the
  opposite of the coexistence behavior this issue asks for)
- `observal_cli/cmd_auth.py` — a new `_install_or_check_pi_extension()` runs
  unconditionally in `_post_login_setup()` alongside skill install (no prompt); failures
  are caught and printed so login never fails because of this
- `observal_cli/harness/pi.py` — `detect_hooks()` now recognizes a configured npm
  package as "installed", not just the local file

## How Has This Been Tested?

- `tests/test_pi_extension.py` (new, 28 tests) covers the state machine directly: missing,
  current, stale, newer-not-downgraded, npm-configured (pinned current/stale/unpinned),
  unmanaged-file conflict, pre-manifest adoption, dry-run, and parent-directory creation.
- Updated `tests/test_cmd_doctor.py`, `tests/test_cli_doctor_commands.py`,
  `tests/test_cmd_auth.py`, `tests/test_cli_harness_adapters.py` for the new behavior
  (418 tests total across these five files, all passing).
- `uv build --wheel` verified to include both `observal_cli/pi_extension.py` and the
  bundled `observal_cli/_bundled/observal.ts`.
- `ruff check` / `ruff format --check` clean on all changed files.
- Not yet done: a live `observal auth login` / `observal doctor patch --harness pi` pass
  against a real `~/.pi/agent` install — recommend doing that manually before merge.

Reproduce:
```bash
make test
uv build --wheel -o /tmp/wheel-check && unzip -l /tmp/wheel-check/*.whl | grep -E "pi_extension|_bundled"
```
## Learning (optional, can help others)

Exploration turned up that this issue was already partially implemented — bundling and
a local-install path existed, but with an inverted design (npm treated as legacy to
migrate away from, rather than a coexisting first-class path). Worth knowing if you're
reviewing: the diff to `cmd_doctor.py` reworks existing `_check_pi`/`_patch_pi`/
`_cleanup_pi` behavior, it isn't purely additive.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes (Claude Code)
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pi telemetry extensions are now installed or refreshed automatically after login when needed.
  * Added support for managing npm-configured and local Pi extensions, including version checks and adoption of existing installations.
* **Bug Fixes**
  * Login remains successful even if Pi extension setup encounters an error.
  * Unmanaged extensions and npm registrations are preserved during maintenance.
* **Documentation**
  * Documented Pi configuration files, installation modes, upgrades, and CLI management actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->