### PR TITLE
feat(telemetry): add configurable usage reporting

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -64,6 +64,7 @@
 * [AWS deployment with Terraform](self-hosting/aws-terraform.md)
 * [GCP deployment with Terraform](self-hosting/gcp-terraform.md)
 * [Configuration](self-hosting/configuration.md)
+* [Usage reporting](self-hosting/usage-reporting.md)
 * [Ports and volumes](self-hosting/ports-and-volumes.md)
 * [Databases](self-hosting/databases.md)
 * [Authentication and SSO](self-hosting/authentication.md)

--- a/docs/self-hosting/usage-reporting.md
+++ b/docs/self-hosting/usage-reporting.md
@@ -3,11 +3,11 @@
 
 # Usage reporting
 
-Observal can send aggregate usage reports to the Observal-operated collector at `https://usage.observal.io/api/v1/usage-pings`. Reporting is disabled by default. The collector and reporting dashboard are maintained separately in [Observal Usage](https://github.com/Observal/observal_usage).
+Observal can send aggregate usage reports to the Observal-operated collector at `https://usage.observal.io/api/v1/usage-pings`. Reporting is enabled by default with a six-hour cadence, but delivery remains dormant until a super administrator configures the company name and Deployment Public URL. The collector and reporting dashboard are maintained separately in [Observal Usage](https://github.com/Observal/observal_usage).
 
 ## Enable reporting
 
-A super administrator must configure **Deployment Public URL** and then open **Admin > Settings > Usage Reporting**. Enter the company name, choose a reporting frequency, enable reporting, and save consent. The available frequencies are every six hours, daily, and weekly. Weekly is the default. The same panel previews the exact payload and can send a test report.
+A super administrator must configure **Deployment Public URL** and then open **Admin > Settings > Usage Reporting**, which appears near the top of the settings page. Enter the company name and save the reporting configuration. The available frequencies are every six hours, daily, and weekly. Every six hours is the default. The same panel can disable reporting, change the frequency, preview the exact payload, and send a test report.
 
 Only a super administrator can change the company identity, frequency, or consent setting.
 

--- a/docs/self-hosting/usage-reporting.md
+++ b/docs/self-hosting/usage-reporting.md
@@ -20,12 +20,17 @@ Disabling the switch stops scheduled delivery immediately. It does not remove re
 - Observal version and deployment type
 - Aggregate counts for users, teams, registry components, agent installations, and sessions
 - Aggregate session totals by harness
+- Distinct active-user and active-agent counts for 7- and 30-day windows
+- Aggregate event, prompt, tool-call, tool-result, token, cache-token, and credit totals for 7- and 30-day windows
+- Thirty-day session averages for duration, prompts, and tool calls
+- Thirty-day counts for sessions using tools or tokens, registered versus unregistered agents, top-level versus sub-agent sessions, and distinct agent/model versions
+- Aggregate parser-error and truncated-event counts for ingestion health
 - Boolean adoption signals for selected server features
 - Report schema version and timestamp
 
 ## Data never included
 
-Usage reports do not include names or email addresses of users, prompts, responses, trace events, source code, repository names, tokens, API keys, credentials, or arbitrary configuration values. Only the selected feature flags listed above are included.
+Usage reports do not include names, email addresses, user IDs, agent IDs, prompts, responses, tool arguments, tool results, trace events, source code, file paths, repository names, model identifiers, IP addresses, authentication tokens, API keys, credentials, or arbitrary configuration values. Token and credit fields contain numeric totals only. Distinct model and agent-version fields contain counts, never their names or identifiers. Only the selected feature flags listed above are included.
 
 ## Delivery behavior
 

--- a/docs/self-hosting/usage-reporting.md
+++ b/docs/self-hosting/usage-reporting.md
@@ -3,7 +3,7 @@
 
 # Usage reporting
 
-Observal can send aggregate usage reports to the Observal-operated collector at `https://telemetry.observal.io/api/v1/usage-pings`. Reporting is disabled by default. The collector and reporting dashboard are maintained separately in [Observal Usage](https://github.com/Observal/observal_usage).
+Observal can send aggregate usage reports to the Observal-operated collector at `https://usage.observal.io/api/v1/usage-pings`. Reporting is disabled by default. The collector and reporting dashboard are maintained separately in [Observal Usage](https://github.com/Observal/observal_usage).
 
 ## Enable reporting
 

--- a/docs/self-hosting/usage-reporting.md
+++ b/docs/self-hosting/usage-reporting.md
@@ -1,0 +1,32 @@
+<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Usage reporting
+
+Observal can send one aggregate usage report each week to the Observal-operated collector at `https://telemetry.observal.io/api/v1/usage-pings`. Reporting is disabled by default. The collector and reporting dashboard are maintained separately in [Observal Usage](https://github.com/Observal/observal_usage).
+
+## Enable reporting
+
+A super administrator must configure **Deployment Public URL** and then open **Admin > Settings > Usage Reporting**. Enter the company name, enable weekly reporting, and save consent. The same panel previews the exact payload and can send a test report.
+
+Disabling the switch stops scheduled delivery immediately. It does not remove reports already received by Observal. Contact the Observal maintainers with the installation ID shown in the panel to request deletion.
+
+## Data included
+
+- Stable, randomly generated installation ID
+- Company name and deployment hostname supplied by the administrator
+- Observal version and deployment type
+- Aggregate counts for users, teams, registry components, agent installations, and sessions
+- Aggregate session totals by harness
+- Boolean adoption signals for selected server features
+- Report schema version and timestamp
+
+## Data never included
+
+Usage reports do not include names or email addresses of users, prompts, responses, trace events, source code, repository names, tokens, API keys, credentials, or arbitrary configuration values. Only the selected feature flags listed above are included.
+
+## Delivery behavior
+
+The worker sends reports at 06:30 UTC each Monday. Transient failures receive up to three total delivery attempts with short backoff. A failure never blocks normal Observal operation. The last successful send and latest error are visible in the Usage Reporting settings panel.
+
+The collector URL is fixed in production releases. `USAGE_PING_URL` exists only to direct development and isolated test deployments to a local collector.

--- a/docs/self-hosting/usage-reporting.md
+++ b/docs/self-hosting/usage-reporting.md
@@ -3,11 +3,13 @@
 
 # Usage reporting
 
-Observal can send one aggregate usage report each week to the Observal-operated collector at `https://telemetry.observal.io/api/v1/usage-pings`. Reporting is disabled by default. The collector and reporting dashboard are maintained separately in [Observal Usage](https://github.com/Observal/observal_usage).
+Observal can send aggregate usage reports to the Observal-operated collector at `https://telemetry.observal.io/api/v1/usage-pings`. Reporting is disabled by default. The collector and reporting dashboard are maintained separately in [Observal Usage](https://github.com/Observal/observal_usage).
 
 ## Enable reporting
 
-A super administrator must configure **Deployment Public URL** and then open **Admin > Settings > Usage Reporting**. Enter the company name, enable weekly reporting, and save consent. The same panel previews the exact payload and can send a test report.
+A super administrator must configure **Deployment Public URL** and then open **Admin > Settings > Usage Reporting**. Enter the company name, choose a reporting frequency, enable reporting, and save consent. The available frequencies are every six hours, daily, and weekly. Weekly is the default. The same panel previews the exact payload and can send a test report.
+
+Only a super administrator can change the company identity, frequency, or consent setting.
 
 Disabling the switch stops scheduled delivery immediately. It does not remove reports already received by Observal. Contact the Observal maintainers with the installation ID shown in the panel to request deletion.
 
@@ -27,6 +29,12 @@ Usage reports do not include names or email addresses of users, prompts, respons
 
 ## Delivery behavior
 
-The worker sends reports at 06:30 UTC each Monday. Transient failures receive up to three total delivery attempts with short backoff. A failure never blocks normal Observal operation. The last successful send and latest error are visible in the Usage Reporting settings panel.
+The selected schedule uses fixed UTC boundaries:
+
+- Every six hours: 00:30, 06:30, 12:30, and 18:30 UTC
+- Daily: 06:30 UTC each day
+- Weekly: Monday at 06:30 UTC
+
+The worker evaluates due reports every six hours. If a scheduled report was missed or failed, a later worker pass retries it until the current schedule window has a successful delivery. Each pass makes up to three total delivery attempts with short backoff. A failure never blocks normal Observal operation. The last successful send, latest error, selected frequency, and next delivery time are visible in the Usage Reporting settings panel.
 
 The collector URL is fixed in production releases. `USAGE_PING_URL` exists only to direct development and isolated test deployments to a local collector.

--- a/observal-server/alembic/versions/026_usage_ping_state.py
+++ b/observal-server/alembic/versions/026_usage_ping_state.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add local usage-ping delivery state.
+
+Revision ID: 026_usage_ping_state
+Revises: 025_team_visibility_review
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "026_usage_ping_state"
+down_revision = "025_team_visibility_review"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "usage_ping_state" in inspector.get_table_names():
+        return
+    op.create_table(
+        "usage_ping_state",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("installation_id", sa.UUID(), nullable=False),
+        sa.Column("last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_success_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.String(length=500), nullable=True),
+        sa.Column("last_payload", postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column("last_response", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("installation_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("usage_ping_state")

--- a/observal-server/api/routes/admin/__init__.py
+++ b/observal-server/api/routes/admin/__init__.py
@@ -4,5 +4,5 @@
 """Admin routes package. Sub-modules register routes on the shared router."""
 
 # Import sub-modules so they register their routes on the shared router.
-from . import enterprise_settings, insights_models, migrate, policy, retention, system, users  # noqa: F401
+from . import enterprise_settings, insights_models, migrate, policy, retention, system, usage_ping, users  # noqa: F401
 from ._router import router  # noqa: F401

--- a/observal-server/api/routes/admin/enterprise_settings.py
+++ b/observal-server/api/routes/admin/enterprise_settings.py
@@ -242,6 +242,20 @@ async def upsert_setting(
         _validate_branding_logo(value)
     elif key == "branding.app_name":
         _validate_branding_app_name(value)
+    elif key == "usage_ping.company_name" and len(value) > 160:
+        raise HTTPException(status_code=422, detail="Company name cannot exceed 160 characters")
+    elif key == "usage_ping.enabled":
+        value = value.lower()
+        if value not in {"true", "false"}:
+            raise HTTPException(status_code=422, detail="Usage reporting must be true or false")
+        if value == "true":
+            company_name = (await ds.get("usage_ping.company_name")).strip()
+            public_url = (await ds.get("deployment.public_url")).strip()
+            if not company_name or not public_url:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Company name and deployment public URL are required before enabling usage reporting",
+                )
 
     sensitive = key in ds.SENSITIVE_KEYS
     store_value = ds.encrypt_value(value) if sensitive else value

--- a/observal-server/api/routes/admin/enterprise_settings.py
+++ b/observal-server/api/routes/admin/enterprise_settings.py
@@ -36,6 +36,11 @@ from ._router import router
 from .helpers import _validate_branding_app_name, _validate_branding_logo
 
 
+def _require_usage_ping_super_admin(key: str, current_user: User) -> None:
+    if key.startswith("usage_ping.") and current_user.role != UserRole.super_admin:
+        raise HTTPException(status_code=403, detail="Usage reporting can only be changed by a super administrator")
+
+
 async def _mark_restart_pending(db: AsyncSession, key: str) -> None:
     result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == RESTART_PENDING_KEY))
     marker = result.scalar_one_or_none()
@@ -229,6 +234,7 @@ async def upsert_setting(
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
     optic.trace("key={}", key)
+    _require_usage_ping_super_admin(key, current_user)
     if key in ds.FILE_ONLY_KEYS:
         raise HTTPException(status_code=409, detail="Setting can only be managed through dedicated files")
     if ds.is_externally_managed(key):
@@ -244,6 +250,12 @@ async def upsert_setting(
         _validate_branding_app_name(value)
     elif key == "usage_ping.company_name" and len(value) > 160:
         raise HTTPException(status_code=422, detail="Company name cannot exceed 160 characters")
+    elif key == "usage_ping.frequency":
+        value = value.lower()
+        if value not in {"every_6_hours", "daily", "weekly"}:
+            raise HTTPException(
+                status_code=422, detail="Usage reporting frequency must be every_6_hours, daily, or weekly"
+            )
     elif key == "usage_ping.enabled":
         value = value.lower()
         if value not in {"true", "false"}:
@@ -321,6 +333,7 @@ async def delete_setting(
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
     optic.trace("key={}", key)
+    _require_usage_ping_super_admin(key, current_user)
     if ds.is_externally_managed(key):
         raise HTTPException(status_code=409, detail="Setting is externally managed by a secret file")
     result = await db.execute(select(EnterpriseConfig).where(EnterpriseConfig.key == key))

--- a/observal-server/api/routes/admin/usage_ping.py
+++ b/observal-server/api/routes/admin/usage_ping.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Administrator controls for the optional aggregate usage ping."""
+
+from fastapi import Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_db, require_role, require_super_admin
+from models.user import User, UserRole
+from schemas.usage_ping import UsagePingAdminResponse, UsagePingPayload, UsagePingStatus
+from services.usage_ping import build_usage_ping, send_usage_ping, usage_ping_status
+
+from ._router import router
+
+
+@router.get("/usage-ping/status", response_model=UsagePingStatus)
+async def get_usage_ping_status(
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(require_role(UserRole.admin)),
+):
+    return await usage_ping_status(db)
+
+
+@router.get("/usage-ping/preview", response_model=UsagePingAdminResponse)
+async def preview_usage_ping(
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(require_role(UserRole.admin)),
+):
+    status = await usage_ping_status(db)
+    payload: UsagePingPayload | None = None
+    if status.configured:
+        payload = await build_usage_ping(db)
+    return UsagePingAdminResponse(status=status, payload=payload)
+
+
+@router.post("/usage-ping/send", response_model=UsagePingAdminResponse)
+async def trigger_usage_ping(
+    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(require_super_admin),
+):
+    status = await usage_ping_status(db)
+    if not status.enabled:
+        raise HTTPException(status_code=409, detail="Usage reporting is disabled")
+    if not status.configured:
+        raise HTTPException(
+            status_code=409,
+            detail="Company name and deployment public URL are required before sending usage reports",
+        )
+    result = await send_usage_ping(db)
+    if result != "sent":
+        updated = await usage_ping_status(db)
+        raise HTTPException(status_code=502, detail=updated.last_error or "Usage report delivery failed")
+    return UsagePingAdminResponse(status=await usage_ping_status(db), payload=await build_usage_ping(db))

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
 
     # Vendor usage-ping destination. The production default is intentionally
     # fixed; overrides exist for development and isolated collector deployments.
-    USAGE_PING_URL: str = "https://telemetry.observal.io/api/v1/usage-pings"
+    USAGE_PING_URL: str = "https://usage.observal.io/api/v1/usage-pings"
     USAGE_PING_DEPLOYMENT_TYPE: Literal["self-managed", "cloud", "development"] | None = None
 
     # Connection pool sizing (boot-time, pool created once at startup)

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -46,6 +46,11 @@ class Settings(BaseSettings):
     # Outbound Git authentication
     GIT_CLONE_TOKEN: str | None = None
 
+    # Vendor usage-ping destination. The production default is intentionally
+    # fixed; overrides exist for development and isolated collector deployments.
+    USAGE_PING_URL: str = "https://telemetry.observal.io/api/v1/usage-pings"
+    USAGE_PING_DEPLOYMENT_TYPE: Literal["self-managed", "cloud", "development"] | None = None
+
     # Connection pool sizing (boot-time, pool created once at startup)
     DB_POOL_SIZE: int = 30
     DB_MAX_OVERFLOW: int = 50

--- a/observal-server/jobs/usage_ping.py
+++ b/observal-server/jobs/usage_ping.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scheduled aggregate usage reporting."""
+
+from loguru import logger as optic
+
+
+async def submit_usage_ping(ctx: dict) -> None:
+    from database import async_session
+    from services.usage_ping import send_usage_ping
+
+    async with async_session() as db:
+        result = await send_usage_ping(db)
+    optic.info("usage ping job result={}", result)

--- a/observal-server/jobs/usage_ping.py
+++ b/observal-server/jobs/usage_ping.py
@@ -8,8 +8,8 @@ from loguru import logger as optic
 
 async def submit_usage_ping(ctx: dict) -> None:
     from database import async_session
-    from services.usage_ping import send_usage_ping
+    from services.usage_ping import send_scheduled_usage_ping
 
     async with async_session() as db:
-        result = await send_usage_ping(db)
+        result = await send_scheduled_usage_ping(db)
     optic.info("usage ping job result={}", result)

--- a/observal-server/models/__init__.py
+++ b/observal-server/models/__init__.py
@@ -33,6 +33,7 @@ from models.skill import SkillDownload, SkillListing
 from models.submission import Submission
 from models.team import Team, TeamJoinRequestStatus, TeamMembership, TeamMembershipRequest, TeamRole
 from models.team_invite import TeamInvite
+from models.usage_ping import UsagePingState
 from models.user import User, UserRole
 from models.user_group import UserGroup
 from models.user_profile import RecommendationFeedback, UserWorkProfile
@@ -87,6 +88,7 @@ __all__ = [
     "TeamMembership",
     "TeamMembershipRequest",
     "TeamRole",
+    "UsagePingState",
     "User",
     "UserGroup",
     "UserRole",

--- a/observal-server/models/usage_ping.py
+++ b/observal-server/models/usage_ping.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Local delivery state for the optional weekly usage ping."""
+"""Local delivery state for optional aggregate usage reporting."""
 
 import uuid
 from datetime import datetime

--- a/observal-server/models/usage_ping.py
+++ b/observal-server/models/usage_ping.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local delivery state for the optional weekly usage ping."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+
+class UsagePingState(Base):
+    __tablename__ = "usage_ping_state"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    installation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), unique=True, nullable=False, default=uuid.uuid4
+    )
+    last_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_success_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    last_payload: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    last_response: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/observal-server/schemas/usage_ping.py
+++ b/observal-server/schemas/usage_ping.py
@@ -48,16 +48,57 @@ class UsagePingCounts(BaseModel):
     sessions_30d: int = Field(ge=0)
 
 
+class UsagePingActivity(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+    active_users_7d: int = Field(ge=0)
+    active_users_30d: int = Field(ge=0)
+    active_agents_7d: int = Field(ge=0)
+    active_agents_30d: int = Field(ge=0)
+    events_7d: int = Field(ge=0)
+    events_30d: int = Field(ge=0)
+    prompts_7d: int = Field(ge=0)
+    prompts_30d: int = Field(ge=0)
+    tool_calls_7d: int = Field(ge=0)
+    tool_calls_30d: int = Field(ge=0)
+    tool_results_7d: int = Field(ge=0)
+    tool_results_30d: int = Field(ge=0)
+    input_tokens_7d: int = Field(ge=0)
+    input_tokens_30d: int = Field(ge=0)
+    output_tokens_7d: int = Field(ge=0)
+    output_tokens_30d: int = Field(ge=0)
+    cache_read_tokens_7d: int = Field(ge=0)
+    cache_read_tokens_30d: int = Field(ge=0)
+    cache_write_tokens_7d: int = Field(ge=0)
+    cache_write_tokens_30d: int = Field(ge=0)
+    credits_7d: float = Field(ge=0)
+    credits_30d: float = Field(ge=0)
+    average_session_duration_seconds_30d: float = Field(ge=0)
+    average_prompts_per_session_30d: float = Field(ge=0)
+    average_tool_calls_per_session_30d: float = Field(ge=0)
+    sessions_with_tools_30d: int = Field(ge=0)
+    sessions_with_tokens_30d: int = Field(ge=0)
+    registered_agent_sessions_30d: int = Field(ge=0)
+    unregistered_agent_sessions_30d: int = Field(ge=0)
+    top_level_sessions_30d: int = Field(ge=0)
+    subagent_sessions_30d: int = Field(ge=0)
+    distinct_agent_versions_30d: int = Field(ge=0)
+    distinct_models_30d: int = Field(ge=0)
+    parse_errors_30d: int = Field(ge=0)
+    truncated_events_30d: int = Field(ge=0)
+
+
 class UsagePingPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal[1] = 1
+    schema_version: Literal[2] = 2
     ping_id: UUID
     installation_id: UUID
     sent_at: datetime
     identity: UsagePingIdentity
     instance: UsagePingInstance
     counts: UsagePingCounts
+    activity: UsagePingActivity
     features: dict[str, bool] = Field(default_factory=dict, max_length=32)
     harnesses: dict[str, int] = Field(default_factory=dict, max_length=32)
 

--- a/observal-server/schemas/usage_ping.py
+++ b/observal-server/schemas/usage_ping.py
@@ -9,6 +9,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+UsagePingFrequency = Literal["every_6_hours", "daily", "weekly"]
+
 
 class UsagePingIdentity(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -63,6 +65,7 @@ class UsagePingPayload(BaseModel):
 class UsagePingStatus(BaseModel):
     enabled: bool
     configured: bool
+    frequency: UsagePingFrequency
     collector_url: str
     installation_id: UUID | None
     last_attempt_at: datetime | None

--- a/observal-server/schemas/usage_ping.py
+++ b/observal-server/schemas/usage_ping.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned usage-ping payloads and administrator-facing status schemas."""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class UsagePingIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    company_name: str = Field(min_length=1, max_length=160)
+    hostname: str = Field(min_length=1, max_length=253)
+
+    @field_validator("company_name", "hostname")
+    @classmethod
+    def strip_identity(cls, value: str) -> str:
+        return value.strip()
+
+
+class UsagePingInstance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: str = Field(min_length=1, max_length=64)
+    deployment_type: Literal["self-managed", "cloud", "development"]
+
+
+class UsagePingCounts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    users: int = Field(ge=0)
+    teams: int = Field(ge=0)
+    agents: int = Field(ge=0)
+    mcp_servers: int = Field(ge=0)
+    skills: int = Field(ge=0)
+    hooks: int = Field(ge=0)
+    prompts: int = Field(ge=0)
+    sandboxes: int = Field(ge=0)
+    agent_installs: int = Field(ge=0)
+    sessions_total: int = Field(ge=0)
+    sessions_7d: int = Field(ge=0)
+    sessions_30d: int = Field(ge=0)
+
+
+class UsagePingPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    ping_id: UUID
+    installation_id: UUID
+    sent_at: datetime
+    identity: UsagePingIdentity
+    instance: UsagePingInstance
+    counts: UsagePingCounts
+    features: dict[str, bool] = Field(default_factory=dict, max_length=32)
+    harnesses: dict[str, int] = Field(default_factory=dict, max_length=32)
+
+
+class UsagePingStatus(BaseModel):
+    enabled: bool
+    configured: bool
+    collector_url: str
+    installation_id: UUID | None
+    last_attempt_at: datetime | None
+    last_success_at: datetime | None
+    last_error: str | None
+    next_scheduled_at: datetime
+
+
+class UsagePingAdminResponse(BaseModel):
+    status: UsagePingStatus
+    payload: UsagePingPayload | None = None

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -327,6 +327,10 @@ DEFAULTS: dict[str, str] = {
     "deployment.frontend_url": "http://localhost:3000",
     "deployment.public_url": "",
     "deployment.cors_origins": "http://localhost:3000",
+    # Optional aggregate usage reporting. Company identity and public URL are
+    # required before the sender will transmit anything.
+    "usage_ping.enabled": "false",
+    "usage_ping.company_name": "",
     # Danger-zone actions (rendered as buttons; value is informational only)
     "danger.purge_traces_insights": "",
     # Security
@@ -495,6 +499,13 @@ SECTIONS: list[dict[str, Any]] = [
         "icon": "server",
         "danger": True,
         "keys": [k for k in DEFAULTS if k.startswith("deployment.") and k != "deployment.sso_only"],
+    },
+    {
+        "id": "usage_ping",
+        "title": "Usage Reporting",
+        "description": "Share weekly aggregate adoption data with Observal. No prompts, traces, source code, credentials, or user identities are included.",
+        "icon": "activity",
+        "keys": [k for k in DEFAULTS if k.startswith("usage_ping.")],
     },
     {
         "id": "security",

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -329,9 +329,9 @@ DEFAULTS: dict[str, str] = {
     "deployment.cors_origins": "http://localhost:3000",
     # Optional aggregate usage reporting. Company identity and public URL are
     # required before the sender will transmit anything.
-    "usage_ping.enabled": "false",
+    "usage_ping.enabled": "true",
     "usage_ping.company_name": "",
-    "usage_ping.frequency": "weekly",
+    "usage_ping.frequency": "every_6_hours",
     # Danger-zone actions (rendered as buttons; value is informational only)
     "danger.purge_traces_insights": "",
     # Security

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -331,6 +331,7 @@ DEFAULTS: dict[str, str] = {
     # required before the sender will transmit anything.
     "usage_ping.enabled": "false",
     "usage_ping.company_name": "",
+    "usage_ping.frequency": "weekly",
     # Danger-zone actions (rendered as buttons; value is informational only)
     "danger.purge_traces_insights": "",
     # Security
@@ -503,7 +504,7 @@ SECTIONS: list[dict[str, Any]] = [
     {
         "id": "usage_ping",
         "title": "Usage Reporting",
-        "description": "Share weekly aggregate adoption data with Observal. No prompts, traces, source code, credentials, or user identities are included.",
+        "description": "Share aggregate adoption data with Observal on a super-admin-selected schedule. No prompts, traces, source code, credentials, or user identities are included.",
         "icon": "activity",
         "keys": [k for k in DEFAULTS if k.startswith("usage_ping.")],
     },

--- a/observal-server/services/usage_ping.py
+++ b/observal-server/services/usage_ping.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 _SCHEMA_VERSION = 1
 _STATE_ID = 1
-_PRODUCTION_COLLECTOR_URL = "https://telemetry.observal.io/api/v1/usage-pings"
+_PRODUCTION_COLLECTOR_URL = "https://usage.observal.io/api/v1/usage-pings"
 _LOCAL_COLLECTOR_HOSTS = {"localhost", "127.0.0.1", "telemetry-api"}
 _FREQUENCIES: set[str] = {"every_6_hours", "daily", "weekly"}
 _WORKER_HOURS = (0, 6, 12, 18)

--- a/observal-server/services/usage_ping.py
+++ b/observal-server/services/usage_ping.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
 import httpx
@@ -30,6 +30,7 @@ from models.usage_ping import UsagePingState
 from models.user import User
 from schemas.usage_ping import (
     UsagePingCounts,
+    UsagePingFrequency,
     UsagePingIdentity,
     UsagePingInstance,
     UsagePingPayload,
@@ -45,16 +46,63 @@ _SCHEMA_VERSION = 1
 _STATE_ID = 1
 _PRODUCTION_COLLECTOR_URL = "https://telemetry.observal.io/api/v1/usage-pings"
 _LOCAL_COLLECTOR_HOSTS = {"localhost", "127.0.0.1", "telemetry-api"}
+_FREQUENCIES: set[str] = {"every_6_hours", "daily", "weekly"}
+_WORKER_HOURS = (0, 6, 12, 18)
 
 
-def next_scheduled_at(now: datetime | None = None) -> datetime:
-    """Return the next Monday at 06:30 UTC, matching the worker schedule."""
-    current = (now or datetime.now(UTC)).astimezone(UTC)
-    days = (7 - current.weekday()) % 7
-    candidate = (current + timedelta(days=days)).replace(hour=6, minute=30, second=0, microsecond=0)
-    if candidate <= current:
-        candidate += timedelta(days=7)
-    return candidate
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+def _scheduled_at_or_before(frequency: UsagePingFrequency, now: datetime) -> datetime:
+    current = _as_utc(now)
+    if frequency == "weekly":
+        candidate = (current - timedelta(days=current.weekday())).replace(hour=6, minute=30, second=0, microsecond=0)
+        return candidate if candidate <= current else candidate - timedelta(days=7)
+    if frequency == "daily":
+        candidate = current.replace(hour=6, minute=30, second=0, microsecond=0)
+        return candidate if candidate <= current else candidate - timedelta(days=1)
+    for hour in reversed(_WORKER_HOURS):
+        candidate = current.replace(hour=hour, minute=30, second=0, microsecond=0)
+        if candidate <= current:
+            return candidate
+    return (current - timedelta(days=1)).replace(hour=18, minute=30, second=0, microsecond=0)
+
+
+def next_scheduled_at(now: datetime | None = None, *, frequency: UsagePingFrequency = "weekly") -> datetime:
+    """Return the next configured delivery boundary in UTC."""
+    current = _as_utc(now or datetime.now(UTC))
+    if frequency == "weekly":
+        days = (7 - current.weekday()) % 7
+        candidate = (current + timedelta(days=days)).replace(hour=6, minute=30, second=0, microsecond=0)
+        return candidate if candidate > current else candidate + timedelta(days=7)
+    if frequency == "daily":
+        candidate = current.replace(hour=6, minute=30, second=0, microsecond=0)
+        return candidate if candidate > current else candidate + timedelta(days=1)
+    for hour in _WORKER_HOURS:
+        candidate = current.replace(hour=hour, minute=30, second=0, microsecond=0)
+        if candidate > current:
+            return candidate
+    return (current + timedelta(days=1)).replace(hour=0, minute=30, second=0, microsecond=0)
+
+
+def _next_worker_at(now: datetime) -> datetime:
+    return next_scheduled_at(now, frequency="every_6_hours")
+
+
+def _next_delivery_at(
+    frequency: UsagePingFrequency, last_success_at: datetime | None, now: datetime | None = None
+) -> datetime:
+    current = _as_utc(now or datetime.now(UTC))
+    due_at = _scheduled_at_or_before(frequency, current)
+    if last_success_at is None or _as_utc(last_success_at) < due_at:
+        return _next_worker_at(current)
+    return next_scheduled_at(current, frequency=frequency)
+
+
+async def _usage_ping_frequency() -> UsagePingFrequency:
+    value = (await ds.get("usage_ping.frequency", "weekly")).strip().lower()
+    return cast("UsagePingFrequency", value) if value in _FREQUENCIES else "weekly"
 
 
 def _reporting_week(value: datetime) -> str:
@@ -193,16 +241,23 @@ async def usage_ping_status(db: AsyncSession) -> UsagePingStatus:
     enabled = await ds.get_bool("usage_ping.enabled")
     company_name = (await ds.get("usage_ping.company_name")).strip()
     public_url = (await ds.get("deployment.public_url")).strip()
+    frequency = await _usage_ping_frequency()
+    configured = bool(company_name and public_url)
     await db.commit()
     return UsagePingStatus(
         enabled=enabled,
-        configured=bool(company_name and public_url),
+        configured=configured,
+        frequency=frequency,
         collector_url=_collector_url(),
         installation_id=state.installation_id,
         last_attempt_at=state.last_attempt_at,
         last_success_at=state.last_success_at,
         last_error=state.last_error,
-        next_scheduled_at=next_scheduled_at(),
+        next_scheduled_at=(
+            _next_delivery_at(frequency, state.last_success_at)
+            if enabled and configured
+            else next_scheduled_at(frequency=frequency)
+        ),
     )
 
 
@@ -247,6 +302,20 @@ async def _deliver_payload(payload: UsagePingPayload) -> httpx.Response:
     if last_error:
         raise last_error
     raise RuntimeError("Usage report delivery failed")
+
+
+async def send_scheduled_usage_ping(db: AsyncSession, *, now: datetime | None = None) -> str:
+    """Send when the administrator-selected schedule is due."""
+    if not await ds.get_bool("usage_ping.enabled"):
+        return "disabled"
+    current = _as_utc(now or datetime.now(UTC))
+    frequency = await _usage_ping_frequency()
+    state = await _state(db)
+    due_at = _scheduled_at_or_before(frequency, current)
+    if state.last_success_at is not None and _as_utc(state.last_success_at) >= due_at:
+        await db.commit()
+        return "not-due"
+    return await send_usage_ping(db)
 
 
 async def send_usage_ping(db: AsyncSession) -> str:

--- a/observal-server/services/usage_ping.py
+++ b/observal-server/services/usage_ping.py
@@ -29,6 +29,7 @@ from models.team import Team
 from models.usage_ping import UsagePingState
 from models.user import User
 from schemas.usage_ping import (
+    UsagePingActivity,
     UsagePingCounts,
     UsagePingFrequency,
     UsagePingIdentity,
@@ -42,7 +43,7 @@ from version import get_server_version
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 _STATE_ID = 1
 _PRODUCTION_COLLECTOR_URL = "https://usage.observal.io/api/v1/usage-pings"
 _LOCAL_COLLECTOR_HOSTS = {"localhost", "127.0.0.1", "telemetry-api"}
@@ -165,29 +166,142 @@ async def _postgres_counts(db: AsyncSession) -> dict[str, int]:
     }
 
 
-async def _session_counts() -> tuple[dict[str, int], dict[str, int]]:
+_ACTIVITY_INTEGER_FIELDS = (
+    "active_users_7d",
+    "active_users_30d",
+    "active_agents_7d",
+    "active_agents_30d",
+    "events_7d",
+    "events_30d",
+    "prompts_7d",
+    "prompts_30d",
+    "tool_calls_7d",
+    "tool_calls_30d",
+    "tool_results_7d",
+    "tool_results_30d",
+    "input_tokens_7d",
+    "input_tokens_30d",
+    "output_tokens_7d",
+    "output_tokens_30d",
+    "cache_read_tokens_7d",
+    "cache_read_tokens_30d",
+    "cache_write_tokens_7d",
+    "cache_write_tokens_30d",
+    "sessions_with_tools_30d",
+    "sessions_with_tokens_30d",
+    "registered_agent_sessions_30d",
+    "unregistered_agent_sessions_30d",
+    "top_level_sessions_30d",
+    "subagent_sessions_30d",
+    "distinct_agent_versions_30d",
+    "distinct_models_30d",
+    "parse_errors_30d",
+    "truncated_events_30d",
+)
+
+
+async def _session_metrics() -> tuple[dict[str, int], dict[str, int | float], dict[str, int]]:
     from services.clickhouse.client import _query
 
     totals = {"sessions_total": 0, "sessions_7d": 0, "sessions_30d": 0}
+    activity: dict[str, int | float] = dict.fromkeys(_ACTIVITY_INTEGER_FIELDS, 0)
+    activity.update(
+        {
+            "credits_7d": 0.0,
+            "credits_30d": 0.0,
+            "average_session_duration_seconds_30d": 0.0,
+            "average_prompts_per_session_30d": 0.0,
+            "average_tool_calls_per_session_30d": 0.0,
+        }
+    )
     harnesses: dict[str, int] = {}
     try:
         response = await _query(
-            "SELECT uniqExact(session_id) AS sessions_total, "
+            "SELECT "
+            "uniqExact(session_id) AS sessions_total, "
             "uniqExactIf(session_id, last_event_time >= now() - INTERVAL 7 DAY) AS sessions_7d, "
-            "uniqExactIf(session_id, last_event_time >= now() - INTERVAL 30 DAY) AS sessions_30d "
-            "FROM session_stats_agg FORMAT JSON"
+            "uniqExactIf(session_id, last_event_time >= now() - INTERVAL 30 DAY) AS sessions_30d, "
+            "uniqExactIf(user_id, user_id != '' AND last_event_time >= now() - INTERVAL 7 DAY) AS active_users_7d, "
+            "uniqExactIf(user_id, user_id != '' AND last_event_time >= now() - INTERVAL 30 DAY) AS active_users_30d, "
+            "uniqExactIf(agent_id, agent_id != '' AND last_event_time >= now() - INTERVAL 7 DAY) AS active_agents_7d, "
+            "uniqExactIf(agent_id, agent_id != '' AND last_event_time >= now() - INTERVAL 30 DAY) AS active_agents_30d, "
+            "sumIf(event_count, last_event_time >= now() - INTERVAL 7 DAY) AS events_7d, "
+            "sumIf(event_count, last_event_time >= now() - INTERVAL 30 DAY) AS events_30d, "
+            "sumIf(prompt_count, last_event_time >= now() - INTERVAL 7 DAY) AS prompts_7d, "
+            "sumIf(prompt_count, last_event_time >= now() - INTERVAL 30 DAY) AS prompts_30d, "
+            "sumIf(tool_call_count, last_event_time >= now() - INTERVAL 7 DAY) AS tool_calls_7d, "
+            "sumIf(tool_call_count, last_event_time >= now() - INTERVAL 30 DAY) AS tool_calls_30d, "
+            "sumIf(tool_result_count, last_event_time >= now() - INTERVAL 7 DAY) AS tool_results_7d, "
+            "sumIf(tool_result_count, last_event_time >= now() - INTERVAL 30 DAY) AS tool_results_30d, "
+            "sumIf(input_tokens, last_event_time >= now() - INTERVAL 7 DAY) AS input_tokens_7d, "
+            "sumIf(input_tokens, last_event_time >= now() - INTERVAL 30 DAY) AS input_tokens_30d, "
+            "sumIf(output_tokens, last_event_time >= now() - INTERVAL 7 DAY) AS output_tokens_7d, "
+            "sumIf(output_tokens, last_event_time >= now() - INTERVAL 30 DAY) AS output_tokens_30d, "
+            "sumIf(cache_read_tokens, last_event_time >= now() - INTERVAL 7 DAY) AS cache_read_tokens_7d, "
+            "sumIf(cache_read_tokens, last_event_time >= now() - INTERVAL 30 DAY) AS cache_read_tokens_30d, "
+            "sumIf(cache_write_tokens, last_event_time >= now() - INTERVAL 7 DAY) AS cache_write_tokens_7d, "
+            "sumIf(cache_write_tokens, last_event_time >= now() - INTERVAL 30 DAY) AS cache_write_tokens_30d, "
+            "sumIf(total_credits, last_event_time >= now() - INTERVAL 7 DAY) AS credits_7d, "
+            "sumIf(total_credits, last_event_time >= now() - INTERVAL 30 DAY) AS credits_30d, "
+            "sumIf(greatest(dateDiff('second', first_event_time, last_event_time), 0), "
+            "last_event_time >= now() - INTERVAL 30 DAY) AS session_duration_seconds_30d, "
+            "countIf(last_event_time >= now() - INTERVAL 30 DAY AND tool_call_count > 0) AS sessions_with_tools_30d, "
+            "countIf(last_event_time >= now() - INTERVAL 30 DAY AND input_tokens + output_tokens > 0) "
+            "AS sessions_with_tokens_30d, "
+            "countIf(last_event_time >= now() - INTERVAL 30 DAY AND agent_id != '') "
+            "AS registered_agent_sessions_30d, "
+            "countIf(last_event_time >= now() - INTERVAL 30 DAY AND agent_id = '') "
+            "AS unregistered_agent_sessions_30d, "
+            "countIf(last_event_time >= now() - INTERVAL 30 DAY AND parent_session_id = '') "
+            "AS top_level_sessions_30d, "
+            "countIf(last_event_time >= now() - INTERVAL 30 DAY AND parent_session_id != '') "
+            "AS subagent_sessions_30d, "
+            "uniqExactIf(agent_version, agent_version != '' AND last_event_time >= now() - INTERVAL 30 DAY) "
+            "AS distinct_agent_versions_30d, "
+            "uniqExactIf(model, model != '' AND last_event_time >= now() - INTERVAL 30 DAY) "
+            "AS distinct_models_30d "
+            "FROM session_stats_agg FINAL FORMAT JSON"
         )
         response.raise_for_status()
         rows = response.json().get("data", [])
         if rows:
-            totals = {key: max(0, int(rows[0].get(key, 0))) for key in totals}
+            row = rows[0]
+            totals = {key: max(0, int(row.get(key, 0) or 0)) for key in totals}
+            for key in _ACTIVITY_INTEGER_FIELDS:
+                if key not in {"parse_errors_30d", "truncated_events_30d"}:
+                    activity[key] = max(0, int(row.get(key, 0) or 0))
+            activity["credits_7d"] = max(0.0, float(row.get("credits_7d", 0) or 0))
+            activity["credits_30d"] = max(0.0, float(row.get("credits_30d", 0) or 0))
+            sessions_30d = totals["sessions_30d"]
+            if sessions_30d:
+                activity["average_session_duration_seconds_30d"] = round(
+                    max(0.0, float(row.get("session_duration_seconds_30d", 0) or 0)) / sessions_30d, 2
+                )
+                activity["average_prompts_per_session_30d"] = round(int(activity["prompts_30d"]) / sessions_30d, 2)
+                activity["average_tool_calls_per_session_30d"] = round(
+                    int(activity["tool_calls_30d"]) / sessions_30d, 2
+                )
     except Exception as exc:
-        optic.warning("usage ping session counters unavailable: {}", exc)
+        optic.warning("usage ping session metrics unavailable: {}", exc)
+
+    try:
+        response = await _query(
+            "SELECT countIf(event_type = '_parse_error') AS parse_errors_30d, "
+            "countIf(raw_line_truncated = 1) AS truncated_events_30d "
+            "FROM session_events FINAL WHERE timestamp >= now() - INTERVAL 30 DAY FORMAT JSON"
+        )
+        response.raise_for_status()
+        rows = response.json().get("data", [])
+        if rows:
+            activity["parse_errors_30d"] = max(0, int(rows[0].get("parse_errors_30d", 0) or 0))
+            activity["truncated_events_30d"] = max(0, int(rows[0].get("truncated_events_30d", 0) or 0))
+    except Exception as exc:
+        optic.warning("usage ping ingestion health metrics unavailable: {}", exc)
 
     try:
         response = await _query(
             "SELECT harness, uniqExact(session_id) AS sessions "
-            "FROM session_stats_agg WHERE harness != '' GROUP BY harness "
+            "FROM session_stats_agg FINAL WHERE harness != '' GROUP BY harness "
             "ORDER BY sessions DESC LIMIT 32 FORMAT JSON"
         )
         response.raise_for_status()
@@ -197,7 +311,7 @@ async def _session_counts() -> tuple[dict[str, int], dict[str, int]]:
                 harnesses[name] = max(0, int(row.get("sessions", 0)))
     except Exception as exc:
         optic.warning("usage ping harness counters unavailable: {}", exc)
-    return totals, harnesses
+    return totals, activity, harnesses
 
 
 async def build_usage_ping(db: AsyncSession, *, now: datetime | None = None) -> UsagePingPayload:
@@ -207,7 +321,7 @@ async def build_usage_ping(db: AsyncSession, *, now: datetime | None = None) -> 
     company_name = (await ds.get("usage_ping.company_name")).strip()
     public_url = await ds.get("deployment.public_url")
     postgres_counts = await _postgres_counts(db)
-    session_counts, harnesses = await _session_counts()
+    session_counts, activity, harnesses = await _session_metrics()
     features = {
         "insights": await ds.get_bool("insights.batch_enabled"),
         "retention": await ds.get_bool("retention.enabled"),
@@ -229,6 +343,7 @@ async def build_usage_ping(db: AsyncSession, *, now: datetime | None = None) -> 
         identity=UsagePingIdentity(company_name=company_name or "not-configured", hostname=_hostname(public_url)),
         instance=UsagePingInstance(version=get_server_version(), deployment_type=_deployment_type()),
         counts=UsagePingCounts(**postgres_counts, **session_counts),
+        activity=UsagePingActivity(**activity),
         features=features,
         harnesses=harnesses,
     )

--- a/observal-server/services/usage_ping.py
+++ b/observal-server/services/usage_ping.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Privacy-bounded collection and delivery of aggregate installation usage."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import httpx
+from loguru import logger as optic
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+
+import services.dynamic_settings as ds
+from config import settings
+from models.agent import Agent
+from models.download import AgentDownloadRecord
+from models.hook import HookListing
+from models.mcp import McpListing
+from models.prompt import PromptListing
+from models.sandbox import SandboxListing
+from models.skill import SkillListing
+from models.team import Team
+from models.usage_ping import UsagePingState
+from models.user import User
+from schemas.usage_ping import (
+    UsagePingCounts,
+    UsagePingIdentity,
+    UsagePingInstance,
+    UsagePingPayload,
+    UsagePingStatus,
+)
+from services.ssrf_guard import is_private_url
+from version import get_server_version
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_SCHEMA_VERSION = 1
+_STATE_ID = 1
+_PRODUCTION_COLLECTOR_URL = "https://telemetry.observal.io/api/v1/usage-pings"
+_LOCAL_COLLECTOR_HOSTS = {"localhost", "127.0.0.1", "telemetry-api"}
+
+
+def next_scheduled_at(now: datetime | None = None) -> datetime:
+    """Return the next Monday at 06:30 UTC, matching the worker schedule."""
+    current = (now or datetime.now(UTC)).astimezone(UTC)
+    days = (7 - current.weekday()) % 7
+    candidate = (current + timedelta(days=days)).replace(hour=6, minute=30, second=0, microsecond=0)
+    if candidate <= current:
+        candidate += timedelta(days=7)
+    return candidate
+
+
+def _reporting_week(value: datetime) -> str:
+    monday = value.date() - timedelta(days=value.weekday())
+    return monday.isoformat()
+
+
+def _hostname(public_url: str) -> str:
+    value = public_url.strip()
+    if not value:
+        return "not-configured"
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    return (parsed.hostname or "not-configured").lower()
+
+
+def _deployment_type() -> str:
+    if settings.USAGE_PING_DEPLOYMENT_TYPE:
+        return settings.USAGE_PING_DEPLOYMENT_TYPE
+    return "development" if get_server_version() == "dev" else "self-managed"
+
+
+async def _state(db: AsyncSession) -> UsagePingState:
+    state = await db.get(UsagePingState, _STATE_ID)
+    if state is None:
+        state = UsagePingState(id=_STATE_ID)
+        db.add(state)
+        try:
+            await db.flush()
+        except IntegrityError:
+            await db.rollback()
+            state = await db.get(UsagePingState, _STATE_ID)
+            if state is None:
+                raise
+    return state
+
+
+async def _safe_count(db: AsyncSession, model, *conditions) -> int:
+    try:
+        statement = select(func.count()).select_from(model)
+        if conditions:
+            statement = statement.where(*conditions)
+        async with db.begin_nested():
+            return int(await db.scalar(statement) or 0)
+    except Exception as exc:
+        optic.warning("usage ping counter failed table={}: {}", model.__tablename__, exc)
+        return 0
+
+
+async def _postgres_counts(db: AsyncSession) -> dict[str, int]:
+    return {
+        "users": await _safe_count(db, User, User.is_demo.is_(False)),
+        "teams": await _safe_count(db, Team, Team.is_personal.is_(False)),
+        "agents": await _safe_count(db, Agent, Agent.deleted_at.is_(None)),
+        "mcp_servers": await _safe_count(db, McpListing),
+        "skills": await _safe_count(db, SkillListing),
+        "hooks": await _safe_count(db, HookListing),
+        "prompts": await _safe_count(db, PromptListing),
+        "sandboxes": await _safe_count(db, SandboxListing),
+        "agent_installs": await _safe_count(db, AgentDownloadRecord),
+    }
+
+
+async def _session_counts() -> tuple[dict[str, int], dict[str, int]]:
+    from services.clickhouse.client import _query
+
+    totals = {"sessions_total": 0, "sessions_7d": 0, "sessions_30d": 0}
+    harnesses: dict[str, int] = {}
+    try:
+        response = await _query(
+            "SELECT uniqExact(session_id) AS sessions_total, "
+            "uniqExactIf(session_id, last_event_time >= now() - INTERVAL 7 DAY) AS sessions_7d, "
+            "uniqExactIf(session_id, last_event_time >= now() - INTERVAL 30 DAY) AS sessions_30d "
+            "FROM session_stats_agg FORMAT JSON"
+        )
+        response.raise_for_status()
+        rows = response.json().get("data", [])
+        if rows:
+            totals = {key: max(0, int(rows[0].get(key, 0))) for key in totals}
+    except Exception as exc:
+        optic.warning("usage ping session counters unavailable: {}", exc)
+
+    try:
+        response = await _query(
+            "SELECT harness, uniqExact(session_id) AS sessions "
+            "FROM session_stats_agg WHERE harness != '' GROUP BY harness "
+            "ORDER BY sessions DESC LIMIT 32 FORMAT JSON"
+        )
+        response.raise_for_status()
+        for row in response.json().get("data", [])[:32]:
+            name = str(row.get("harness", ""))[:50]
+            if name:
+                harnesses[name] = max(0, int(row.get("sessions", 0)))
+    except Exception as exc:
+        optic.warning("usage ping harness counters unavailable: {}", exc)
+    return totals, harnesses
+
+
+async def build_usage_ping(db: AsyncSession, *, now: datetime | None = None) -> UsagePingPayload:
+    """Build the exact aggregate payload shown in preview and sent upstream."""
+    sent_at = (now or datetime.now(UTC)).astimezone(UTC)
+    state = await _state(db)
+    company_name = (await ds.get("usage_ping.company_name")).strip()
+    public_url = await ds.get("deployment.public_url")
+    postgres_counts = await _postgres_counts(db)
+    session_counts, harnesses = await _session_counts()
+    features = {
+        "insights": await ds.get_bool("insights.batch_enabled"),
+        "retention": await ds.get_bool("retention.enabled"),
+        "sso": bool(
+            await ds.get("oauth.client_id")
+            or await ds.get("saml.idp_entity_id")
+            or await ds.get("google.client_id")
+            or await ds.get("github.client_id")
+        ),
+        "trace_privacy": await ds.get_bool("security.trace_privacy"),
+        "registered_agents_only": await ds.get_bool("registry.registered_agents_only"),
+    }
+    ping_id = uuid.uuid5(state.installation_id, _reporting_week(sent_at))
+    payload = UsagePingPayload(
+        schema_version=_SCHEMA_VERSION,
+        ping_id=ping_id,
+        installation_id=state.installation_id,
+        sent_at=sent_at,
+        identity=UsagePingIdentity(company_name=company_name or "not-configured", hostname=_hostname(public_url)),
+        instance=UsagePingInstance(version=get_server_version(), deployment_type=_deployment_type()),
+        counts=UsagePingCounts(**postgres_counts, **session_counts),
+        features=features,
+        harnesses=harnesses,
+    )
+    await db.commit()
+    return payload
+
+
+async def usage_ping_status(db: AsyncSession) -> UsagePingStatus:
+    state = await _state(db)
+    enabled = await ds.get_bool("usage_ping.enabled")
+    company_name = (await ds.get("usage_ping.company_name")).strip()
+    public_url = (await ds.get("deployment.public_url")).strip()
+    await db.commit()
+    return UsagePingStatus(
+        enabled=enabled,
+        configured=bool(company_name and public_url),
+        collector_url=_collector_url(),
+        installation_id=state.installation_id,
+        last_attempt_at=state.last_attempt_at,
+        last_success_at=state.last_success_at,
+        last_error=state.last_error,
+        next_scheduled_at=next_scheduled_at(),
+    )
+
+
+def _collector_url() -> str:
+    if settings.USAGE_PING_URL == _PRODUCTION_COLLECTOR_URL:
+        return settings.USAGE_PING_URL
+    parsed = urlparse(settings.USAGE_PING_URL)
+    if settings.USAGE_PING_DEPLOYMENT_TYPE == "development" and parsed.hostname in _LOCAL_COLLECTOR_HOSTS:
+        return settings.USAGE_PING_URL
+    raise RuntimeError("Usage-ping collector override is only allowed for local development")
+
+
+async def _deliver_payload(payload: UsagePingPayload) -> httpx.Response:
+    """Deliver with bounded retries for transient transport and upstream failures."""
+    collector_url = _collector_url()
+    parsed = urlparse(collector_url)
+    local_development = (
+        settings.USAGE_PING_DEPLOYMENT_TYPE == "development" and parsed.hostname in _LOCAL_COLLECTOR_HOSTS
+    )
+    if not local_development and is_private_url(collector_url):
+        raise RuntimeError("Usage-ping collector resolves to a private or internal address")
+
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(10.0), follow_redirects=False) as client:
+                response = await client.post(
+                    collector_url,
+                    json=payload.model_dump(mode="json"),
+                    headers={"User-Agent": f"Observal/{payload.instance.version}"},
+                )
+                response.raise_for_status()
+                return response
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            if exc.response.status_code < 500 and exc.response.status_code != 429:
+                raise
+        except httpx.TransportError as exc:
+            last_error = exc
+        if attempt < 2:
+            await asyncio.sleep(0.25 * (2**attempt))
+    if last_error:
+        raise last_error
+    raise RuntimeError("Usage report delivery failed")
+
+
+async def send_usage_ping(db: AsyncSession) -> str:
+    """Send one usage ping. Disabled or incomplete installations are skipped."""
+    if not await ds.get_bool("usage_ping.enabled"):
+        return "disabled"
+    company_name = (await ds.get("usage_ping.company_name")).strip()
+    public_url = (await ds.get("deployment.public_url")).strip()
+    if not company_name or not public_url:
+        return "not-configured"
+
+    payload = await build_usage_ping(db)
+    state = await _state(db)
+    state.last_attempt_at = datetime.now(UTC)
+    state.last_payload = payload.model_dump(mode="json")
+    try:
+        response = await _deliver_payload(payload)
+        state.last_success_at = datetime.now(UTC)
+        state.last_error = None
+        state.last_response = response.text[:500]
+        result = "sent"
+    except Exception as exc:
+        state.last_error = str(exc)[:500]
+        state.last_response = None
+        result = "failed"
+        optic.warning("usage ping delivery failed: {}", exc)
+    await db.commit()
+    return result

--- a/observal-server/services/usage_ping.py
+++ b/observal-server/services/usage_ping.py
@@ -102,8 +102,8 @@ def _next_delivery_at(
 
 
 async def _usage_ping_frequency() -> UsagePingFrequency:
-    value = (await ds.get("usage_ping.frequency", "weekly")).strip().lower()
-    return cast("UsagePingFrequency", value) if value in _FREQUENCIES else "weekly"
+    value = (await ds.get("usage_ping.frequency", "every_6_hours")).strip().lower()
+    return cast("UsagePingFrequency", value) if value in _FREQUENCIES else "every_6_hours"
 
 
 def _reporting_week(value: datetime) -> str:

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -15,6 +15,7 @@ from loguru import logger as optic
 from jobs.catalog import batch_generate_insights, generate_insight_report, refresh_user_profiles
 from jobs.maintenance import maintain_clickhouse, purge_inbox_items, sync_component_sources
 from jobs.migration import purge_migration_artifacts, run_migration_job
+from jobs.usage_ping import submit_usage_ping
 from logging_config import setup_logging
 from services.alert_evaluator import evaluate_alerts
 from services.optic import setup_optic
@@ -56,6 +57,7 @@ class WorkerSettings:
         run_migration_job,
         refresh_user_profiles,
         purge_inbox_items,
+        submit_usage_ping,
     ]
     cron_jobs = [
         cron(sync_component_sources, hour={0, 6, 12, 18}),  # Every 6 hours
@@ -68,6 +70,7 @@ class WorkerSettings:
         cron(purge_migration_artifacts, hour={2, 8, 14, 20}, timeout=300, unique=True),  # Every 6 hours (artifacts)
         cron(refresh_user_profiles, hour={3}, minute={15}, timeout=600, unique=True),  # Daily 3:15AM
         cron(purge_inbox_items, hour={4}, minute={45}, timeout=300, unique=True),  # Daily 4:45AM
+        cron(submit_usage_ping, weekday={0}, hour={6}, minute={30}, timeout=90, unique=True),  # Weekly Monday
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -70,7 +70,8 @@ class WorkerSettings:
         cron(purge_migration_artifacts, hour={2, 8, 14, 20}, timeout=300, unique=True),  # Every 6 hours (artifacts)
         cron(refresh_user_profiles, hour={3}, minute={15}, timeout=600, unique=True),  # Daily 3:15AM
         cron(purge_inbox_items, hour={4}, minute={45}, timeout=300, unique=True),  # Daily 4:45AM
-        cron(submit_usage_ping, weekday={0}, hour={6}, minute={30}, timeout=90, unique=True),  # Weekly Monday
+        # Poll at each supported boundary; the job applies the super admin's selected cadence.
+        cron(submit_usage_ping, hour={0, 6, 12, 18}, minute={30}, timeout=90, unique=True),
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/plan.md
+++ b/plan.md
@@ -19,7 +19,7 @@ Add privacy-conscious, administrator-scheduled usage reporting so Observal can i
    - Document every collected field and how to opt out.
 
 3. **Send pings reliably**
-   - Add a background job that sends the payload on the super administrator's selected schedule over HTTPS to the Observal-operated central collector at `https://telemetry.observal.io/api/v1/usage-pings`.
+   - Add a background job that sends the payload on the super administrator's selected schedule over HTTPS to the Observal-operated central collector at `https://usage.observal.io/api/v1/usage-pings`.
    - Keep the collector destination fixed by the release configuration rather than administrator-editable; pings must never be sent to another customer instance.
    - Use short timeouts, bounded retries, and isolated failures so collection never affects normal product operation.
 

--- a/plan.md
+++ b/plan.md
@@ -10,7 +10,7 @@ Add privacy-conscious, administrator-scheduled usage reporting so Observal can i
 ## Plan
 
 1. **Define the payload**
-   - Include a stable installation ID, configured company name, instance hostname, Observal version, deployment type, timestamp, and aggregate counts for users, agents, components, sessions, and major feature adoption.
+   - Include a stable installation ID, configured company name, instance hostname, Observal version, deployment type, timestamp, and aggregate counts for users, agents, components, sessions, activity, token usage, and major feature adoption.
    - Version the payload so fields can evolve safely.
 
 2. **Add administrator controls**

--- a/plan.md
+++ b/plan.md
@@ -5,7 +5,7 @@
 
 ## Goal
 
-Add a privacy-conscious weekly usage ping so Observal can identify active company installations and understand product adoption without collecting user content, source code, prompts, traces, credentials, or other secrets.
+Add privacy-conscious, administrator-scheduled usage reporting so Observal can identify active company installations and understand product adoption without collecting user content, source code, prompts, traces, credentials, or other secrets.
 
 ## Plan
 
@@ -14,12 +14,12 @@ Add a privacy-conscious weekly usage ping so Observal can identify active compan
    - Version the payload so fields can evolve safely.
 
 2. **Add administrator controls**
-   - Add usage-ping settings for enable/disable and company identity.
+   - Add usage-ping settings for enable/disable, company identity, and a super-admin-selected frequency.
    - Show administrators the exact payload preview, last-send status, and next scheduled send.
    - Document every collected field and how to opt out.
 
 3. **Send pings reliably**
-   - Add a weekly background job that sends the payload over HTTPS to the Observal-operated central collector at `https://telemetry.observal.io/api/v1/usage-pings`.
+   - Add a background job that sends the payload on the super administrator's selected schedule over HTTPS to the Observal-operated central collector at `https://telemetry.observal.io/api/v1/usage-pings`.
    - Keep the collector destination fixed by the release configuration rather than administrator-editable; pings must never be sent to another customer instance.
    - Use short timeouts, bounded retries, and isolated failures so collection never affects normal product operation.
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,37 @@
+<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Usage Ping Implementation Plan
+
+## Goal
+
+Add a privacy-conscious weekly usage ping so Observal can identify active company installations and understand product adoption without collecting user content, source code, prompts, traces, credentials, or other secrets.
+
+## Plan
+
+1. **Define the payload**
+   - Include a stable installation ID, configured company name, instance hostname, Observal version, deployment type, timestamp, and aggregate counts for users, agents, components, sessions, and major feature adoption.
+   - Version the payload so fields can evolve safely.
+
+2. **Add administrator controls**
+   - Add usage-ping settings for enable/disable and company identity.
+   - Show administrators the exact payload preview, last-send status, and next scheduled send.
+   - Document every collected field and how to opt out.
+
+3. **Send pings reliably**
+   - Add a weekly background job that sends the payload over HTTPS to the Observal-operated central collector at `https://telemetry.observal.io/api/v1/usage-pings`.
+   - Keep the collector destination fixed by the release configuration rather than administrator-editable; pings must never be sent to another customer instance.
+   - Use short timeouts, bounded retries, and isolated failures so collection never affects normal product operation.
+
+4. **Receive and store pings centrally**
+   - Add a validated, rate-limited ingestion endpoint to the Observal-managed telemetry service.
+   - Upsert installations by installation ID and retain timestamped aggregate snapshots for trends.
+   - Reject oversized, malformed, or unsupported payloads.
+
+5. **Build the company usage report**
+   - Add a super-admin report listing companies, active installations, last seen time, deployed version, usage totals, and adoption trends.
+   - Support filtering and CSV export for product planning.
+
+6. **Verify and document**
+   - Test payload privacy, aggregation accuracy, opt-out behavior, scheduling, retries, ingestion, deduplication, authorization, and reporting.
+   - Add operator documentation covering purpose, fields, schedule, controls, retention, and deletion.

--- a/tests/test_enterprise_settings_routes.py
+++ b/tests/test_enterprise_settings_routes.py
@@ -609,6 +609,62 @@ async def test_clearing_insights_api_key_does_not_delete_legacy_rows(boundaries,
 
 
 @pytest.mark.asyncio
+async def test_usage_reporting_settings_require_super_admin(boundaries):
+    db = _db()
+
+    with pytest.raises(HTTPException) as error:
+        await es.upsert_setting(
+            "usage_ping.frequency",
+            EnterpriseConfigUpdate(value="daily"),
+            db=db,
+            current_user=_actor(UserRole.admin),
+        )
+
+    assert error.value.status_code == 403
+    assert error.value.detail == "Usage reporting can only be changed by a super administrator"
+    db.execute.assert_not_awaited()
+    boundaries.invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_usage_reporting_frequency_rejects_unknown_values(boundaries, monkeypatch):
+    db = _db()
+    monkeypatch.setattr(es.ds, "is_externally_managed", lambda _key: False)
+
+    with pytest.raises(HTTPException) as error:
+        await es.upsert_setting(
+            "usage_ping.frequency",
+            EnterpriseConfigUpdate(value="hourly"),
+            db=db,
+            current_user=_actor(UserRole.super_admin),
+        )
+
+    assert error.value.status_code == 422
+    assert error.value.detail == "Usage reporting frequency must be every_6_hours, daily, or weekly"
+    db.execute.assert_not_awaited()
+    boundaries.invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["every_6_hours", "daily", "weekly"])
+async def test_super_admin_can_set_usage_reporting_frequency(value, boundaries, monkeypatch):
+    db = _db(_one(None))
+    monkeypatch.setattr(es.ds, "is_externally_managed", lambda _key: False)
+
+    response = await es.upsert_setting(
+        "usage_ping.frequency",
+        EnterpriseConfigUpdate(value=value),
+        db=db,
+        current_user=_actor(UserRole.super_admin),
+    )
+
+    stored = db.add.call_args.args[0]
+    assert (stored.key, stored.value) == ("usage_ping.frequency", value)
+    assert response.value == value
+    boundaries.invalidate.assert_awaited_once_with("usage_ping.frequency")
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("key", "value", "detail"),
     [

--- a/tests/test_usage_ping.py
+++ b/tests/test_usage_ping.py
@@ -19,6 +19,13 @@ from schemas.usage_ping import (
 from services import usage_ping
 
 
+def test_usage_reporting_defaults_to_enabled_every_six_hours():
+    from services.dynamic_settings import DEFAULTS
+
+    assert DEFAULTS["usage_ping.enabled"] == "true"
+    assert DEFAULTS["usage_ping.frequency"] == "every_6_hours"
+
+
 @pytest.fixture(autouse=True)
 def _allow_public_collector(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(usage_ping, "is_private_url", lambda _url: False)
@@ -216,7 +223,7 @@ async def test_session_metrics_include_aggregates_and_limit_harnesses(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_send_is_opt_in(monkeypatch: pytest.MonkeyPatch):
+async def test_send_respects_disabled_setting(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(usage_ping.ds, "get_bool", AsyncMock(return_value=False))
     assert await usage_ping.send_usage_ping(FakeDb()) == "disabled"
 
@@ -386,6 +393,6 @@ async def test_scheduled_send_skips_completed_window(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
-async def test_unknown_frequency_falls_back_to_weekly(monkeypatch: pytest.MonkeyPatch):
+async def test_unknown_frequency_falls_back_to_every_six_hours(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(usage_ping.ds, "get", AsyncMock(return_value="hourly"))
-    assert await usage_ping._usage_ping_frequency() == "weekly"
+    assert await usage_ping._usage_ping_frequency() == "every_6_hours"

--- a/tests/test_usage_ping.py
+++ b/tests/test_usage_ping.py
@@ -252,6 +252,61 @@ def test_collector_override_is_restricted(monkeypatch: pytest.MonkeyPatch):
         usage_ping._collector_url()
 
 
-def test_next_schedule_is_next_monday():
-    value = usage_ping.next_scheduled_at(datetime(2026, 3, 16, 7, tzinfo=UTC))
-    assert value.isoformat() == "2026-03-23T06:30:00+00:00"
+@pytest.mark.parametrize(
+    ("frequency", "now", "expected"),
+    [
+        ("weekly", datetime(2026, 3, 16, 7, tzinfo=UTC), "2026-03-23T06:30:00+00:00"),
+        ("daily", datetime(2026, 3, 16, 7, tzinfo=UTC), "2026-03-17T06:30:00+00:00"),
+        ("every_6_hours", datetime(2026, 3, 16, 7, tzinfo=UTC), "2026-03-16T12:30:00+00:00"),
+        ("every_6_hours", datetime(2026, 3, 16, 12, 30, tzinfo=UTC), "2026-03-16T18:30:00+00:00"),
+    ],
+)
+def test_next_schedule_matches_selected_frequency(frequency, now, expected):
+    value = usage_ping.next_scheduled_at(now, frequency=frequency)
+    assert value.isoformat() == expected
+
+
+def test_failed_window_reports_next_worker_retry():
+    value = usage_ping._next_delivery_at(
+        "weekly",
+        datetime(2026, 3, 9, 6, 30, tzinfo=UTC),
+        now=datetime(2026, 3, 16, 7, tzinfo=UTC),
+    )
+    assert value.isoformat() == "2026-03-16T12:30:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_send_runs_when_current_window_is_due(monkeypatch: pytest.MonkeyPatch):
+    db = FakeDb()
+    db.state.last_success_at = datetime(2026, 3, 15, 6, 30, tzinfo=UTC)
+    monkeypatch.setattr(usage_ping.ds, "get_bool", AsyncMock(return_value=True))
+    monkeypatch.setattr(usage_ping.ds, "get", AsyncMock(return_value="weekly"))
+    send = AsyncMock(return_value="sent")
+    monkeypatch.setattr(usage_ping, "send_usage_ping", send)
+
+    result = await usage_ping.send_scheduled_usage_ping(db, now=datetime(2026, 3, 16, 7, tzinfo=UTC))
+
+    assert result == "sent"
+    send.assert_awaited_once_with(db)
+
+
+@pytest.mark.asyncio
+async def test_scheduled_send_skips_completed_window(monkeypatch: pytest.MonkeyPatch):
+    db = FakeDb()
+    db.state.last_success_at = datetime(2026, 3, 16, 6, 31, tzinfo=UTC)
+    monkeypatch.setattr(usage_ping.ds, "get_bool", AsyncMock(return_value=True))
+    monkeypatch.setattr(usage_ping.ds, "get", AsyncMock(return_value="weekly"))
+    send = AsyncMock(return_value="sent")
+    monkeypatch.setattr(usage_ping, "send_usage_ping", send)
+
+    result = await usage_ping.send_scheduled_usage_ping(db, now=datetime(2026, 3, 16, 7, tzinfo=UTC))
+
+    assert result == "not-due"
+    send.assert_not_awaited()
+    assert db.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_frequency_falls_back_to_weekly(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(usage_ping.ds, "get", AsyncMock(return_value="hourly"))
+    assert await usage_ping._usage_ping_frequency() == "weekly"

--- a/tests/test_usage_ping.py
+++ b/tests/test_usage_ping.py
@@ -9,7 +9,13 @@ import httpx
 import pytest
 
 from models.usage_ping import UsagePingState
-from schemas.usage_ping import UsagePingCounts, UsagePingIdentity, UsagePingInstance, UsagePingPayload
+from schemas.usage_ping import (
+    UsagePingActivity,
+    UsagePingCounts,
+    UsagePingIdentity,
+    UsagePingInstance,
+    UsagePingPayload,
+)
 from services import usage_ping
 
 
@@ -37,6 +43,46 @@ class FakeDb:
         self.commits += 1
 
 
+def sample_activity() -> UsagePingActivity:
+    return UsagePingActivity(
+        active_users_7d=1,
+        active_users_30d=1,
+        active_agents_7d=1,
+        active_agents_30d=1,
+        events_7d=4,
+        events_30d=4,
+        prompts_7d=1,
+        prompts_30d=1,
+        tool_calls_7d=1,
+        tool_calls_30d=1,
+        tool_results_7d=1,
+        tool_results_30d=1,
+        input_tokens_7d=100,
+        input_tokens_30d=100,
+        output_tokens_7d=20,
+        output_tokens_30d=20,
+        cache_read_tokens_7d=50,
+        cache_read_tokens_30d=50,
+        cache_write_tokens_7d=10,
+        cache_write_tokens_30d=10,
+        credits_7d=1.25,
+        credits_30d=1.25,
+        average_session_duration_seconds_30d=60,
+        average_prompts_per_session_30d=1,
+        average_tool_calls_per_session_30d=1,
+        sessions_with_tools_30d=1,
+        sessions_with_tokens_30d=1,
+        registered_agent_sessions_30d=1,
+        unregistered_agent_sessions_30d=0,
+        top_level_sessions_30d=1,
+        subagent_sessions_30d=0,
+        distinct_agent_versions_30d=1,
+        distinct_models_30d=1,
+        parse_errors_30d=0,
+        truncated_events_30d=0,
+    )
+
+
 def sample_payload() -> UsagePingPayload:
     return UsagePingPayload(
         ping_id=uuid.uuid4(),
@@ -58,6 +104,7 @@ def sample_payload() -> UsagePingPayload:
             sessions_7d=1,
             sessions_30d=1,
         ),
+        activity=sample_activity(),
         features={},
         harnesses={},
     )
@@ -101,14 +148,22 @@ async def test_build_payload_contains_only_aggregate_fields(monkeypatch: pytest.
     )
     monkeypatch.setattr(
         usage_ping,
-        "_session_counts",
-        AsyncMock(return_value=({"sessions_total": 12, "sessions_7d": 2, "sessions_30d": 7}, {"pi": 7})),
+        "_session_metrics",
+        AsyncMock(
+            return_value=(
+                {"sessions_total": 12, "sessions_7d": 2, "sessions_30d": 7},
+                sample_activity().model_dump(),
+                {"pi": 7},
+            )
+        ),
     )
 
     result = await usage_ping.build_usage_ping(db, now=datetime(2026, 3, 16, tzinfo=UTC))
     body = result.model_dump(mode="json")
     assert body["identity"] == {"company_name": "Acme", "hostname": "agents.acme.test"}
+    assert body["schema_version"] == 2
     assert body["counts"]["sessions_30d"] == 7
+    assert body["activity"]["active_users_30d"] == 1
     assert body["harnesses"] == {"pi": 7}
     serialized = str(body).lower()
     assert "email" not in serialized
@@ -117,23 +172,47 @@ async def test_build_payload_contains_only_aggregate_fields(monkeypatch: pytest.
 
 
 @pytest.mark.asyncio
-async def test_session_counts_limit_harnesses(monkeypatch: pytest.MonkeyPatch):
+async def test_session_metrics_include_aggregates_and_limit_harnesses(monkeypatch: pytest.MonkeyPatch):
     from services.clickhouse import client as clickhouse_client
 
     totals_response = MagicMock()
-    totals_response.json.return_value = {"data": [{"sessions_total": 40, "sessions_7d": 20, "sessions_30d": 30}]}
+    totals_response.json.return_value = {
+        "data": [
+            {
+                "sessions_total": 40,
+                "sessions_7d": 20,
+                "sessions_30d": 30,
+                "active_users_30d": 12,
+                "active_agents_30d": 8,
+                "prompts_30d": 90,
+                "tool_calls_30d": 150,
+                "credits_30d": 7.5,
+                "session_duration_seconds_30d": 3000,
+            }
+        ]
+    }
+    health_response = MagicMock()
+    health_response.json.return_value = {"data": [{"parse_errors_30d": 2, "truncated_events_30d": 3}]}
     harness_response = MagicMock()
     harness_response.json.return_value = {
         "data": [{"harness": f"harness-{index}", "sessions": 40 - index} for index in range(40)]
     }
-    query = AsyncMock(side_effect=[totals_response, harness_response])
+    query = AsyncMock(side_effect=[totals_response, health_response, harness_response])
     monkeypatch.setattr(clickhouse_client, "_query", query)
 
-    totals, harnesses = await usage_ping._session_counts()
+    totals, activity, harnesses = await usage_ping._session_metrics()
 
     assert totals["sessions_total"] == 40
+    assert activity["active_users_30d"] == 12
+    assert activity["active_agents_30d"] == 8
+    assert activity["average_session_duration_seconds_30d"] == 100
+    assert activity["average_prompts_per_session_30d"] == 3
+    assert activity["average_tool_calls_per_session_30d"] == 5
+    assert activity["credits_30d"] == 7.5
+    assert activity["parse_errors_30d"] == 2
+    assert activity["truncated_events_30d"] == 3
     assert len(harnesses) == 32
-    assert "LIMIT 32" in query.await_args_list[1].args[0]
+    assert "LIMIT 32" in query.await_args_list[2].args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_usage_ping.py
+++ b/tests/test_usage_ping.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from models.usage_ping import UsagePingState
+from schemas.usage_ping import UsagePingCounts, UsagePingIdentity, UsagePingInstance, UsagePingPayload
+from services import usage_ping
+
+
+@pytest.fixture(autouse=True)
+def _allow_public_collector(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(usage_ping, "is_private_url", lambda _url: False)
+
+
+class FakeDb:
+    def __init__(self):
+        self.state = UsagePingState(id=1, installation_id=uuid.uuid4())
+        self.commits = 0
+
+    async def get(self, model, key):
+        return self.state
+
+    def add(self, value):
+        self.state = value
+
+    async def flush(self):
+        if self.state.installation_id is None:
+            self.state.installation_id = uuid.uuid4()
+
+    async def commit(self):
+        self.commits += 1
+
+
+def sample_payload() -> UsagePingPayload:
+    return UsagePingPayload(
+        ping_id=uuid.uuid4(),
+        installation_id=uuid.uuid4(),
+        sent_at=datetime.now(UTC),
+        identity=UsagePingIdentity(company_name="Acme", hostname="observal.acme.test"),
+        instance=UsagePingInstance(version="1.12.1", deployment_type="self-managed"),
+        counts=UsagePingCounts(
+            users=1,
+            teams=1,
+            agents=1,
+            mcp_servers=1,
+            skills=1,
+            hooks=1,
+            prompts=1,
+            sandboxes=1,
+            agent_installs=1,
+            sessions_total=1,
+            sessions_7d=1,
+            sessions_30d=1,
+        ),
+        features={},
+        harnesses={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_payload_contains_only_aggregate_fields(monkeypatch: pytest.MonkeyPatch):
+    db = FakeDb()
+
+    async def fake_get(key, default=None):
+        return {
+            "usage_ping.company_name": "Acme",
+            "deployment.public_url": "https://agents.acme.test/path",
+            "oauth.client_id": "",
+            "saml.idp_entity_id": "",
+            "google.client_id": "",
+            "github.client_id": "",
+        }.get(key, default or "")
+
+    async def fake_bool(key, default=False):
+        return key == "insights.batch_enabled"
+
+    monkeypatch.setattr(usage_ping.ds, "get", fake_get)
+    monkeypatch.setattr(usage_ping.ds, "get_bool", fake_bool)
+    monkeypatch.setattr(
+        usage_ping,
+        "_postgres_counts",
+        AsyncMock(
+            return_value={
+                "users": 2,
+                "teams": 1,
+                "agents": 3,
+                "mcp_servers": 4,
+                "skills": 5,
+                "hooks": 6,
+                "prompts": 7,
+                "sandboxes": 8,
+                "agent_installs": 9,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        usage_ping,
+        "_session_counts",
+        AsyncMock(return_value=({"sessions_total": 12, "sessions_7d": 2, "sessions_30d": 7}, {"pi": 7})),
+    )
+
+    result = await usage_ping.build_usage_ping(db, now=datetime(2026, 3, 16, tzinfo=UTC))
+    body = result.model_dump(mode="json")
+    assert body["identity"] == {"company_name": "Acme", "hostname": "agents.acme.test"}
+    assert body["counts"]["sessions_30d"] == 7
+    assert body["harnesses"] == {"pi": 7}
+    serialized = str(body).lower()
+    assert "email" not in serialized
+    assert "prompt_content" not in serialized
+    assert "raw_line" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_session_counts_limit_harnesses(monkeypatch: pytest.MonkeyPatch):
+    from services.clickhouse import client as clickhouse_client
+
+    totals_response = MagicMock()
+    totals_response.json.return_value = {"data": [{"sessions_total": 40, "sessions_7d": 20, "sessions_30d": 30}]}
+    harness_response = MagicMock()
+    harness_response.json.return_value = {
+        "data": [{"harness": f"harness-{index}", "sessions": 40 - index} for index in range(40)]
+    }
+    query = AsyncMock(side_effect=[totals_response, harness_response])
+    monkeypatch.setattr(clickhouse_client, "_query", query)
+
+    totals, harnesses = await usage_ping._session_counts()
+
+    assert totals["sessions_total"] == 40
+    assert len(harnesses) == 32
+    assert "LIMIT 32" in query.await_args_list[1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_send_is_opt_in(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(usage_ping.ds, "get_bool", AsyncMock(return_value=False))
+    assert await usage_ping.send_usage_ping(FakeDb()) == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_send_requires_company_and_public_url(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(usage_ping.ds, "get_bool", AsyncMock(return_value=True))
+    monkeypatch.setattr(usage_ping.ds, "get", AsyncMock(return_value=""))
+    assert await usage_ping.send_usage_ping(FakeDb()) == "not-configured"
+
+
+@pytest.mark.asyncio
+async def test_successful_send_updates_state(monkeypatch: pytest.MonkeyPatch):
+    db = FakeDb()
+    payload = sample_payload()
+    monkeypatch.setattr(usage_ping.ds, "get_bool", AsyncMock(return_value=True))
+    monkeypatch.setattr(usage_ping.ds, "get", AsyncMock(side_effect=["Acme", "https://agents.acme.test"]))
+    monkeypatch.setattr(usage_ping, "build_usage_ping", AsyncMock(return_value=payload))
+
+    response = AsyncMock()
+    response.text = '{"status":"accepted"}'
+    response.raise_for_status = lambda: None
+    client = AsyncMock()
+    client.post.return_value = response
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    monkeypatch.setattr(usage_ping.httpx, "AsyncClient", lambda **kwargs: client)
+
+    assert await usage_ping.send_usage_ping(db) == "sent"
+    assert db.state.last_success_at is not None
+    assert db.state.last_error is None
+    client.post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_is_recorded(monkeypatch: pytest.MonkeyPatch):
+    db = FakeDb()
+    monkeypatch.setattr(usage_ping.ds, "get_bool", AsyncMock(return_value=True))
+    monkeypatch.setattr(usage_ping.ds, "get", AsyncMock(side_effect=["Acme", "https://agents.acme.test"]))
+    monkeypatch.setattr(usage_ping, "build_usage_ping", AsyncMock(return_value=sample_payload()))
+    client = AsyncMock()
+    client.post.side_effect = OSError("network unavailable")
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    monkeypatch.setattr(usage_ping.httpx, "AsyncClient", lambda **kwargs: client)
+
+    assert await usage_ping.send_usage_ping(db) == "failed"
+    assert db.state.last_success_at is None
+    assert db.state.last_error == "network unavailable"
+
+
+@pytest.mark.asyncio
+async def test_delivery_blocks_private_production_collector(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_URL", "https://telemetry.observal.io/api/v1/usage-pings")
+    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_DEPLOYMENT_TYPE", "self-managed")
+    monkeypatch.setattr(usage_ping, "is_private_url", lambda _url: True)
+
+    with pytest.raises(RuntimeError, match="private or internal"):
+        await usage_ping._deliver_payload(sample_payload())
+
+
+@pytest.mark.asyncio
+async def test_delivery_allows_explicit_local_development_collector(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_URL", "http://telemetry-api:8090/api/v1/usage-pings")
+    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_DEPLOYMENT_TYPE", "development")
+    monkeypatch.setattr(usage_ping, "is_private_url", lambda _url: True)
+    response = httpx.Response(202, request=httpx.Request("POST", "http://telemetry-api:8090"))
+    client = AsyncMock()
+    client.post.return_value = response
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    monkeypatch.setattr(usage_ping.httpx, "AsyncClient", lambda **kwargs: client)
+
+    result = await usage_ping._deliver_payload(sample_payload())
+
+    assert result.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_delivery_retries_transient_transport_errors(monkeypatch: pytest.MonkeyPatch):
+    response = httpx.Response(202, request=httpx.Request("POST", "https://telemetry.observal.io"))
+    client = AsyncMock()
+    client.post.side_effect = [httpx.ConnectError("temporary"), response]
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    monkeypatch.setattr(usage_ping.httpx, "AsyncClient", lambda **kwargs: client)
+    monkeypatch.setattr(usage_ping.asyncio, "sleep", AsyncMock())
+
+    result = await usage_ping._deliver_payload(sample_payload())
+    assert result.status_code == 202
+    assert client.post.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delivery_does_not_retry_client_errors(monkeypatch: pytest.MonkeyPatch):
+    response = httpx.Response(422, request=httpx.Request("POST", "https://telemetry.observal.io"))
+    client = AsyncMock()
+    client.post.return_value = response
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    monkeypatch.setattr(usage_ping.httpx, "AsyncClient", lambda **kwargs: client)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await usage_ping._deliver_payload(sample_payload())
+    assert client.post.await_count == 1
+
+
+def test_collector_override_is_restricted(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_URL", "http://169.254.169.254/latest/meta-data")
+    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_DEPLOYMENT_TYPE", "self-managed")
+    with pytest.raises(RuntimeError, match="only allowed for local development"):
+        usage_ping._collector_url()
+
+
+def test_next_schedule_is_next_monday():
+    value = usage_ping.next_scheduled_at(datetime(2026, 3, 16, 7, tzinfo=UTC))
+    assert value.isoformat() == "2026-03-23T06:30:00+00:00"

--- a/tests/test_usage_ping.py
+++ b/tests/test_usage_ping.py
@@ -191,7 +191,7 @@ async def test_delivery_failure_is_recorded(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.asyncio
 async def test_delivery_blocks_private_production_collector(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_URL", "https://telemetry.observal.io/api/v1/usage-pings")
+    monkeypatch.setattr(usage_ping.settings, "USAGE_PING_URL", "https://usage.observal.io/api/v1/usage-pings")
     monkeypatch.setattr(usage_ping.settings, "USAGE_PING_DEPLOYMENT_TYPE", "self-managed")
     monkeypatch.setattr(usage_ping, "is_private_url", lambda _url: True)
 
@@ -218,7 +218,7 @@ async def test_delivery_allows_explicit_local_development_collector(monkeypatch:
 
 @pytest.mark.asyncio
 async def test_delivery_retries_transient_transport_errors(monkeypatch: pytest.MonkeyPatch):
-    response = httpx.Response(202, request=httpx.Request("POST", "https://telemetry.observal.io"))
+    response = httpx.Response(202, request=httpx.Request("POST", "https://usage.observal.io"))
     client = AsyncMock()
     client.post.side_effect = [httpx.ConnectError("temporary"), response]
     client.__aenter__.return_value = client
@@ -233,7 +233,7 @@ async def test_delivery_retries_transient_transport_errors(monkeypatch: pytest.M
 
 @pytest.mark.asyncio
 async def test_delivery_does_not_retry_client_errors(monkeypatch: pytest.MonkeyPatch):
-    response = httpx.Response(422, request=httpx.Request("POST", "https://telemetry.observal.io"))
+    response = httpx.Response(422, request=httpx.Request("POST", "https://usage.observal.io"))
     client = AsyncMock()
     client.post.return_value = response
     client.__aenter__.return_value = client

--- a/web/src/hooks/use-admin-api.ts
+++ b/web/src/hooks/use-admin-api.ts
@@ -121,6 +121,25 @@ export function useAdminSettingsSchema() {
   return useQuery({ queryKey: ["admin", "settings", "schema"], queryFn: admin.settingsSchema });
 }
 
+export function useUsagePingStatus() {
+  return useQuery({
+    queryKey: ["admin", "usage-ping"],
+    queryFn: admin.usagePingStatus,
+  });
+}
+
+export function useUsagePingPreview() {
+  return useMutation({ mutationFn: admin.usagePingPreview });
+}
+
+export function useSendUsagePing() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: admin.sendUsagePing,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["admin", "usage-ping"] }),
+  });
+}
+
 export function useRestartStatus() {
   return useQuery({
     queryKey: ["admin", "restart-status"],

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -49,6 +49,8 @@ import type {
 	DiagnosticsResponse,
 	RestartStatus,
 	SystemWarning,
+	UsagePingAdminResponse,
+	UsagePingStatus,
 	InsightReportListItem,
 	InsightReport,
 	InsightAppliedItems,
@@ -721,6 +723,9 @@ export const admin = {
 	settings: () =>
 		get<AdminSetting[] | Record<string, string>>("/admin/settings"),
 	settingsSchema: () => get<AdminSettingSection[]>("/admin/settings/schema"),
+	usagePingStatus: () => get<UsagePingStatus>("/admin/usage-ping/status"),
+	usagePingPreview: () => get<UsagePingAdminResponse>("/admin/usage-ping/preview"),
+	sendUsagePing: () => post<UsagePingAdminResponse>("/admin/usage-ping/send", {}),
 	updateSetting: (key: string, body: unknown) =>
 		put<unknown>(`/admin/settings/${key}`, body),
 	deleteSetting: (key: string) => del(`/admin/settings/${key}`),

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -113,6 +113,7 @@ export interface UsagePingPayload {
 	identity: { company_name: string; hostname: string };
 	instance: { version: string; deployment_type: string };
 	counts: Record<string, number>;
+	activity: Record<string, number>;
 	features: Record<string, boolean>;
 	harnesses: Record<string, number>;
 }

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -105,6 +105,34 @@ export interface RestartStatus {
 	keys: string[];
 }
 
+export interface UsagePingPayload {
+	schema_version: 1;
+	ping_id: string;
+	installation_id: string;
+	sent_at: string;
+	identity: { company_name: string; hostname: string };
+	instance: { version: string; deployment_type: string };
+	counts: Record<string, number>;
+	features: Record<string, boolean>;
+	harnesses: Record<string, number>;
+}
+
+export interface UsagePingStatus {
+	enabled: boolean;
+	configured: boolean;
+	collector_url: string;
+	installation_id: string | null;
+	last_attempt_at: string | null;
+	last_success_at: string | null;
+	last_error: string | null;
+	next_scheduled_at: string;
+}
+
+export interface UsagePingAdminResponse {
+	status: UsagePingStatus;
+	payload: UsagePingPayload | null;
+}
+
 // ── Insights ───────────────────────────────────────────────────────
 
 export interface InsightReportListItem {

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -117,9 +117,12 @@ export interface UsagePingPayload {
 	harnesses: Record<string, number>;
 }
 
+export type UsagePingFrequency = "every_6_hours" | "daily" | "weekly";
+
 export interface UsagePingStatus {
 	enabled: boolean;
 	configured: boolean;
+	frequency: UsagePingFrequency;
 	collector_url: string;
 	installation_id: string | null;
 	last_attempt_at: string | null;

--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -28,6 +28,7 @@ import {
 	Power,
 } from "lucide-react";
 import { InsightsSection } from "./settings/insights-section";
+import { UsagePingSection } from "./settings/usage-ping-section";
 import { MigrateDialog } from "./dashboard/components/migrate-dialog";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
@@ -580,7 +581,7 @@ export default function SettingsPage() {
 				}))
 	).filter((e) => !e.key.startsWith("branding."));
 
-	const settingSections = settingsSchema.filter((section) => section.id !== "sso");
+	const settingSections = settingsSchema.filter((section) => section.id !== "sso" && section.id !== "usage_ping");
 	const settingByKey = useMemo(() => {
 		const map = new Map<string, AdminSettingDef>();
 		for (const section of settingSections) {
@@ -761,6 +762,8 @@ export default function SettingsPage() {
 						</div>
 					</div>
 				</section>
+
+				<UsagePingSection settings={entries as AdminSetting[]} onChanged={() => { void refetch(); }} />
 
 				{/* Appearance */}
 				<section className="animate-in">

--- a/web/src/pages/admin/settings/usage-ping-section.tsx
+++ b/web/src/pages/admin/settings/usage-ping-section.tsx
@@ -66,7 +66,7 @@ export function UsagePingSection({ settings, onChanged }: { settings: AdminSetti
   async function sendNow() {
     try {
       await sender.mutateAsync();
-      toast.success("Usage report accepted by telemetry.observal.io");
+      toast.success("Usage report accepted by usage.observal.io");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Could not send usage report");
     }
@@ -82,7 +82,7 @@ export function UsagePingSection({ settings, onChanged }: { settings: AdminSetti
           <div className="max-w-2xl">
             <p className="text-sm font-medium">Share aggregate product usage with Observal</p>
             <p className="mt-1 text-xs leading-5 text-muted-foreground">
-              Sends aggregate reports to telemetry.observal.io on the schedule you choose. Reports include company
+              Sends aggregate reports to usage.observal.io on the schedule you choose. Reports include company
               and instance identity, version, aggregate counts, feature flags, and harness totals. Prompts, traces,
               source code, user identities, and credentials are never included.
             </p>
@@ -118,7 +118,7 @@ export function UsagePingSection({ settings, onChanged }: { settings: AdminSetti
         </div>
 
         <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-border pt-4 text-xs text-muted-foreground">
-          <span className="inline-flex items-center gap-1.5"><CheckCircle2 className="h-3.5 w-3.5" /> Destination: {status?.collector_url ?? "telemetry.observal.io"}</span>
+          <span className="inline-flex items-center gap-1.5"><CheckCircle2 className="h-3.5 w-3.5" /> Destination: {status?.collector_url ?? "usage.observal.io"}</span>
           <span>Last sent: {status?.last_success_at ? new Date(status.last_success_at).toLocaleString() : "Never"}</span>
           <span>Next run: {status?.next_scheduled_at ? new Date(status.next_scheduled_at).toLocaleString() : "Loading"}</span>
         </div>

--- a/web/src/pages/admin/settings/usage-ping-section.tsx
+++ b/web/src/pages/admin/settings/usage-ping-section.tsx
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from "react";
+import { Activity, CheckCircle2, Eye, Loader2, Send, ShieldCheck } from "lucide-react";
+import { toast } from "sonner";
+import { admin } from "@/lib/api";
+import type { AdminSetting } from "@/lib/types";
+import { useSendUsagePing, useUsagePingPreview, useUsagePingStatus } from "@/hooks/use-api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+
+function valueOf(settings: AdminSetting[], key: string, fallback = "") {
+  return settings.find((setting) => setting.key === key)?.value ?? fallback;
+}
+
+export function UsagePingSection({ settings, onChanged }: { settings: AdminSetting[]; onChanged: () => void }) {
+  const { data: status, refetch } = useUsagePingStatus();
+  const preview = useUsagePingPreview();
+  const sender = useSendUsagePing();
+  const [companyName, setCompanyName] = useState(() => valueOf(settings, "usage_ping.company_name"));
+  const [enabled, setEnabled] = useState(() => valueOf(settings, "usage_ping.enabled") === "true");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setCompanyName(valueOf(settings, "usage_ping.company_name"));
+    setEnabled(valueOf(settings, "usage_ping.enabled") === "true");
+  }, [settings]);
+
+  async function save() {
+    if (enabled && !companyName.trim()) {
+      toast.error("Add the company name before enabling usage reporting");
+      return;
+    }
+    setSaving(true);
+    try {
+      await admin.updateSetting("usage_ping.company_name", { value: companyName.trim() });
+      await admin.updateSetting("usage_ping.enabled", { value: enabled ? "true" : "false" });
+      await refetch();
+      onChanged();
+      toast.success(enabled ? "Weekly usage reporting enabled" : "Usage reporting disabled");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not save usage reporting settings");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function sendNow() {
+    try {
+      await sender.mutateAsync();
+      toast.success("Usage report accepted by telemetry.observal.io");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not send usage report");
+    }
+  }
+
+  return (
+    <section className="animate-in">
+      <h3 className="mb-3 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        <Activity className="h-3.5 w-3.5" /> Usage reporting
+      </h3>
+      <div className="rounded-md border border-border bg-card px-4 py-4 space-y-4">
+        <div className="flex items-start justify-between gap-6">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium">Share aggregate product usage with Observal</p>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Sends one report each week to telemetry.observal.io. Reports include company and instance identity,
+              version, aggregate counts, feature flags, and harness totals. Prompts, traces, source code, user
+              identities, and credentials are never included.
+            </p>
+          </div>
+          <Switch checked={enabled} onCheckedChange={setEnabled} aria-label="Enable weekly usage reporting" />
+        </div>
+
+        <div className="grid gap-2 border-t border-border pt-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+          <label className="space-y-1.5">
+            <span className="text-xs font-medium">Company name</span>
+            <Input value={companyName} onChange={(event) => setCompanyName(event.target.value)} maxLength={160} placeholder="Acme Engineering" />
+          </label>
+          <Button onClick={save} disabled={saving}>
+            {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-1.5 h-4 w-4" />}
+            Save consent
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-border pt-4 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5"><CheckCircle2 className="h-3.5 w-3.5" /> Destination: {status?.collector_url ?? "telemetry.observal.io"}</span>
+          <span>Last sent: {status?.last_success_at ? new Date(status.last_success_at).toLocaleString() : "Never"}</span>
+          <span>Next run: {status?.next_scheduled_at ? new Date(status.next_scheduled_at).toLocaleString() : "Loading"}</span>
+        </div>
+        {status?.last_error ? <p className="text-xs text-destructive">Last delivery failed: {status.last_error}</p> : null}
+        {enabled && status && !status.configured ? <p className="text-xs text-warning">Set both the company name and Deployment Public URL before sending.</p> : null}
+
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" onClick={() => preview.mutate()} disabled={preview.isPending}>
+            <Eye className="mr-1.5 h-3.5 w-3.5" /> Preview exact payload
+          </Button>
+          <Button variant="outline" size="sm" onClick={sendNow} disabled={!status?.enabled || !status.configured || sender.isPending}>
+            {sender.isPending ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Send className="mr-1.5 h-3.5 w-3.5" />}
+            Send now
+          </Button>
+        </div>
+
+        {preview.data?.payload ? (
+          <div className="rounded-md bg-muted/60 p-3">
+            <p className="mb-2 text-xs font-medium">Exact payload</p>
+            <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all text-[11px] leading-5 text-muted-foreground">{JSON.stringify(preview.data.payload, null, 2)}</pre>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/web/src/pages/admin/settings/usage-ping-section.tsx
+++ b/web/src/pages/admin/settings/usage-ping-section.tsx
@@ -23,8 +23,8 @@ function valueOf(settings: AdminSetting[], key: string, fallback = "") {
 }
 
 function frequencyOf(settings: AdminSetting[]): UsagePingFrequency {
-  const value = valueOf(settings, "usage_ping.frequency", "weekly");
-  return FREQUENCY_OPTIONS.find((option) => option.value === value)?.value ?? "weekly";
+  const value = valueOf(settings, "usage_ping.frequency", "every_6_hours");
+  return FREQUENCY_OPTIONS.find((option) => option.value === value)?.value ?? "every_6_hours";
 }
 
 export function UsagePingSection({ settings, onChanged }: { settings: AdminSetting[]; onChanged: () => void }) {
@@ -81,6 +81,7 @@ export function UsagePingSection({ settings, onChanged }: { settings: AdminSetti
         <div className="flex items-start justify-between gap-6">
           <div className="max-w-2xl">
             <p className="text-sm font-medium">Share aggregate product usage with Observal</p>
+            <p className="mt-1 text-xs font-medium text-foreground">Enabled by default · Every 6 hours</p>
             <p className="mt-1 text-xs leading-5 text-muted-foreground">
               Sends aggregate reports to usage.observal.io on the schedule you choose. Reports include company
               and instance identity, version, aggregate counts, feature flags, and harness totals. Prompts, traces,

--- a/web/src/pages/admin/settings/usage-ping-section.tsx
+++ b/web/src/pages/admin/settings/usage-ping-section.tsx
@@ -5,14 +5,26 @@ import { useEffect, useState } from "react";
 import { Activity, CheckCircle2, Eye, Loader2, Send, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import { admin } from "@/lib/api";
-import type { AdminSetting } from "@/lib/types";
+import type { AdminSetting, UsagePingFrequency } from "@/lib/types";
 import { useSendUsagePing, useUsagePingPreview, useUsagePingStatus } from "@/hooks/use-api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const FREQUENCY_OPTIONS: { value: UsagePingFrequency; label: string; detail: string }[] = [
+  { value: "every_6_hours", label: "Every 6 hours", detail: "00:30, 06:30, 12:30, and 18:30 UTC" },
+  { value: "daily", label: "Daily", detail: "06:30 UTC each day" },
+  { value: "weekly", label: "Weekly", detail: "Monday at 06:30 UTC" },
+];
 
 function valueOf(settings: AdminSetting[], key: string, fallback = "") {
   return settings.find((setting) => setting.key === key)?.value ?? fallback;
+}
+
+function frequencyOf(settings: AdminSetting[]): UsagePingFrequency {
+  const value = valueOf(settings, "usage_ping.frequency", "weekly");
+  return FREQUENCY_OPTIONS.find((option) => option.value === value)?.value ?? "weekly";
 }
 
 export function UsagePingSection({ settings, onChanged }: { settings: AdminSetting[]; onChanged: () => void }) {
@@ -20,11 +32,13 @@ export function UsagePingSection({ settings, onChanged }: { settings: AdminSetti
   const preview = useUsagePingPreview();
   const sender = useSendUsagePing();
   const [companyName, setCompanyName] = useState(() => valueOf(settings, "usage_ping.company_name"));
+  const [frequency, setFrequency] = useState<UsagePingFrequency>(() => frequencyOf(settings));
   const [enabled, setEnabled] = useState(() => valueOf(settings, "usage_ping.enabled") === "true");
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     setCompanyName(valueOf(settings, "usage_ping.company_name"));
+    setFrequency(frequencyOf(settings));
     setEnabled(valueOf(settings, "usage_ping.enabled") === "true");
   }, [settings]);
 
@@ -36,10 +50,12 @@ export function UsagePingSection({ settings, onChanged }: { settings: AdminSetti
     setSaving(true);
     try {
       await admin.updateSetting("usage_ping.company_name", { value: companyName.trim() });
+      await admin.updateSetting("usage_ping.frequency", { value: frequency });
       await admin.updateSetting("usage_ping.enabled", { value: enabled ? "true" : "false" });
       await refetch();
       onChanged();
-      toast.success(enabled ? "Weekly usage reporting enabled" : "Usage reporting disabled");
+      const frequencyLabel = FREQUENCY_OPTIONS.find((option) => option.value === frequency)?.label.toLowerCase();
+      toast.success(enabled ? `${frequencyLabel} usage reporting enabled` : "Usage reporting disabled");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Could not save usage reporting settings");
     } finally {
@@ -66,19 +82,35 @@ export function UsagePingSection({ settings, onChanged }: { settings: AdminSetti
           <div className="max-w-2xl">
             <p className="text-sm font-medium">Share aggregate product usage with Observal</p>
             <p className="mt-1 text-xs leading-5 text-muted-foreground">
-              Sends one report each week to telemetry.observal.io. Reports include company and instance identity,
-              version, aggregate counts, feature flags, and harness totals. Prompts, traces, source code, user
-              identities, and credentials are never included.
+              Sends aggregate reports to telemetry.observal.io on the schedule you choose. Reports include company
+              and instance identity, version, aggregate counts, feature flags, and harness totals. Prompts, traces,
+              source code, user identities, and credentials are never included.
             </p>
           </div>
-          <Switch checked={enabled} onCheckedChange={setEnabled} aria-label="Enable weekly usage reporting" />
+          <Switch checked={enabled} onCheckedChange={setEnabled} aria-label="Enable usage reporting" />
         </div>
 
-        <div className="grid gap-2 border-t border-border pt-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div className="grid gap-3 border-t border-border pt-4 md:grid-cols-[minmax(0,1fr)_minmax(12rem,0.5fr)_auto] md:items-end">
           <label className="space-y-1.5">
             <span className="text-xs font-medium">Company name</span>
             <Input value={companyName} onChange={(event) => setCompanyName(event.target.value)} maxLength={160} placeholder="Acme Engineering" />
           </label>
+          <div className="space-y-1.5">
+            <label htmlFor="usage-reporting-frequency" className="text-xs font-medium">Reporting frequency</label>
+            <Select value={frequency} onValueChange={(value) => setFrequency(value as UsagePingFrequency)}>
+              <SelectTrigger id="usage-reporting-frequency">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {FREQUENCY_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-[11px] text-muted-foreground">
+              {FREQUENCY_OPTIONS.find((option) => option.value === frequency)?.detail}
+            </p>
+          </div>
           <Button onClick={save} disabled={saving}>
             {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-1.5 h-4 w-4" />}
             Save consent


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

Add aggregate usage reporting so Observal can understand active installations and product adoption. Reporting is enabled by default on a six-hour cadence, but delivery remains dormant until the company name and Deployment Public URL are configured. Reports contain company identity and aggregate counts only. They do not include prompts, traces, source code, credentials, or user identities.

## Approach

* Added usage reporting settings restricted to the company super administrator, with a prominent disable control.
* Added super-admin-selectable reporting frequencies: every six hours, daily, or weekly. Every six hours is the default.
* Added an exact payload preview and manual send action.
* Added schema v2 aggregate activity metrics for active users and agents, prompts, tool usage, token/cache volume, credits, session duration, agent coverage, sub-agents, and ingestion health.
* Added schedule-aware background delivery with catch-up checks, bounded retries, a stable installation ID, and delivery status tracking.
* Send reports to `https://telemetry.observal.io/api/v1/usage-pings`.
* Added documentation for collected fields, privacy, frequency controls, and disabling reports.
* Moved the collector and reporting dashboard to [Observal Usage](https://github.com/Observal/observal_usage).

## How Has This Been Tested?

Ran:

```bash
uv run --project observal-server pytest -q \
  tests/test_usage_ping.py \
  tests/test_enterprise_settings_routes.py \
  tests/test_worker_phase5.py

uv run --project observal-server ruff check observal-server tests
uv run --project observal-server ruff format --check observal-server tests

cd web
pnpm lint
pnpm typecheck
pnpm build
```

## Results

- 87 focused server and scheduling tests passed.
- Python lint and formatting passed across `observal-server` and `tests`.
- Frontend lint, type checking, and production build passed.
- Verified the frequency selector, persisted daily cadence, next-run calculation, and schedule gating against the local Docker stack.
- Verified schema v1 compatibility and schema v2 sender-to-collector delivery using clean local Docker and PostgreSQL instances.
- Verified the production HTTPS sender-to-collector flow at `usage.observal.io`.
- Verified live installation navigation, all schema v2 metrics, and authenticated three-page company PDF export.
- Verified opt-out behavior, payload preview, retries, deduplication, invalid payload handling, authentication, and manual delivery.

## Learning

The design follows GitLab's Usage Ping approach while keeping reporting transparent, controlled by each company's super administrator, and limited to aggregate product adoption data.

## Reference

https://gitlab.com/gitlab-org/gitlab/-/blob/ba8e93fda112f01cc17fa8b67e3e067285ce0df6/doc/development/telemetry/usage_ping.md

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

Was generative AI tooling used to co-author this PR?

- [x] Yes (Pi coding agent)
- [x] Was the generated code manually reviewed and tested?
