### PR TITLE
docs: add optional Discord field to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,3 +44,8 @@ _Was generative AI tooling used to co-author this PR?_
 
 - [ ] Yes(Please Specify the tool):
 - [ ] Was the generated code manually reviewed and tested?
+
+## Discord username (optional)
+_If you would like to be pinged when this PR is reviewed or merged, add your Discord username below._
+
+Discord username:


### PR DESCRIPTION
## Purpose / Description
Add an optional Discord username field to the end of the pull request template so contributors can request a ping when their PR is reviewed or merged.

## Fixes
N/A

## Approach
Added a single optional section with a short explanation and a field for the contributor's Discord username.

## How Has This Been Tested?
Reviewed the rendered Markdown structure and ran `git diff --check`.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code
- [x] UI changes are not applicable

## AI Assistance
- [x] Yes (Pi coding agent)
- [x] The generated change was manually reviewed and tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an optional Discord username field to the pull request template for review or merge notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->