### PR TITLE
fix: keep UUIDs as text in SQLite tests

### DIFF
--- a/observal-server/models/base.py
+++ b/observal-server/models/base.py
@@ -1,7 +1,16 @@
 # SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com>
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import DeclarativeBase
+
+
+@compiles(UUID, "sqlite")
+def _compile_uuid_for_sqlite(_type, _compiler, **_kwargs):
+    """Give PostgreSQL UUID columns text affinity in SQLite-backed tests."""
+    return "CHAR(32)"
 
 
 class Base(DeclarativeBase):

--- a/tests/test_team_review.py
+++ b/tests/test_team_review.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the team-scoped review queue at /api/v1/review.
@@ -185,7 +186,8 @@ async def _seed(sessions):
         co_authors=[],
     )
     agent_version = AgentVersion(
-        id=uuid.uuid4(),
+        # SQLite's NUMERIC affinity used to coerce this valid UUID to float('inf').
+        id=uuid.UUID("1e999999-9999-9999-9999-999999999999"),
         agent_id=agent.id,
         version="1.0.0",
         model_name="claude-sonnet-4-5",


### PR DESCRIPTION
## Purpose / Description
Fix the intermittent Python 3.12 failure seen while merging #1699:

`test_team_id_filter_narrows_to_that_teamspace` failed with `AttributeError: 'float' object has no attribute 'replace'` while SQLAlchemy was decoding a UUID.

PostgreSQL's `UUID` type compiled to `UUID` in SQLite. SQLite assigns that declaration NUMERIC affinity, so UUID hex strings that happen to look like scientific notation can be converted to floats (in this case, `inf`).

## Fixes
N/A

## Approach
- Compile PostgreSQL UUID columns as `CHAR(32)` on SQLite so UUID values retain text affinity.
- Use a deterministic scientific-notation-shaped UUID in the team review fixture to prevent regressions.

This affects SQLite only; PostgreSQL continues using its native UUID type.

## How Has This Been Tested?
- Confirmed the regression test fails with the original compiler and the same `float('inf')` traceback.
- `uv run --python 3.12 pytest ../tests/test_team_review.py -q` — 51 passed.
- Python 3.12 suite excluding macOS-incompatible `test_secret_files.py` — 8501 passed, 21 skipped.
- Ruff check and format check — passed.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes are not applicable

## AI Assistance
- [x] Yes (Pi coding agent)
- [x] The generated code was manually reviewed and tested

## Discord username (optional)

Discord username:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite compatibility for UUID fields.
  * Updated seeded test data to prevent invalid UUID conversions during testing.

* **Documentation**
  * Updated copyright notices with the latest attribution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->