### PR TITLE
docs: add Claude Code integration guide

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -50,7 +50,7 @@ This writes credentials to `~/.observal/config.json`.
 ### 3. Pull an agent into Claude Code
 
 ```bash
-observal agent pull <agent-name> --harness claude-code
+observal pull <agent-name> --harness claude-code
 ```
 
 Claude Code's default scope is project scope. By default, the agent is written to `.claude/agents/{name}.md`.
@@ -58,7 +58,7 @@ Claude Code's default scope is project scope. By default, the agent is written t
 To install into the current user's Claude Code configuration:
 
 ```bash
-observal agent pull <agent-name> --harness claude-code --scope user
+observal pull <agent-name> --harness claude-code --scope user
 ```
 
 User agents are written to `~/.claude/agents/{name}.md`.
@@ -70,7 +70,7 @@ User agents are written to `~/.claude/agents/{name}.md`.
 | Purpose          | Project scope                    | User scope                         |
 | ---------------- | -------------------------------- | ---------------------------------- |
 | Agent profile    | `.claude/agents/{name}.md`       | `~/.claude/agents/{name}.md`       |
-| Skill definition | `.claude/skills/{name}/SKILL.md` | `~/.claude/skills/{name}/SKILL.md` |
+| Skill definition | —                                | `~/.claude/skills/{name}/SKILL.md` |
 | Hook config      | `.claude/settings.json`          | `~/.claude/settings.json`          |
 | MCP config       | `.mcp.json`                      | —                                  |
 
@@ -78,28 +78,27 @@ User agents are written to `~/.claude/agents/{name}.md`.
 
 ## Hook spec
 
-Observal installs session push hooks for `UserPromptSubmit` and `Stop`.
+Observal installs session-push hooks for `UserPromptSubmit` and `Stop`. Each event is configured as a matcher group containing Observal metadata and a nested `hooks` list. The command uses the Python interpreter associated with the Observal CLI installation.
+
+The generated configuration follows this structure:
 
 ```json
 {
   "hooks": {
     "UserPromptSubmit": [
       {
-        "type": "command",
-        "command": "python -m observal_cli.hooks.session_push --harness claude-code"
-      }
-    ],
-    "Stop": [
-      {
-        "type": "command",
-        "command": "python -m observal_cli.hooks.session_push --harness claude-code"
+        "_observal": "...",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<observal-python> -m observal_cli.hooks.session_push --harness claude-code"
+          }
+        ]
       }
     ]
   }
 }
 ```
-
-The Claude Code adapter recognizes `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, and `SubagentStop` hook events.
 
 ---
 
@@ -124,7 +123,7 @@ Observal generates Markdown agent profiles with YAML frontmatter:
 ```markdown
 ---
 name: my-agent
-model: claude-sonnet-4
+model: sonnet
 description: Agent description
 ---
 
@@ -135,13 +134,13 @@ Agent instructions go here.
 
 ## Skill file format
 
-Claude Code skills live at:
+Observal currently manages Claude Code skills at user scope:
 
-| Scope   | Path                               |
-| ------- | ---------------------------------- |
-| Project | `.claude/skills/{name}/SKILL.md`   |
-| User    | `~/.claude/skills/{name}/SKILL.md` |
+| Scope | Path |
+| ----- | ---- |
+| User  | `~/.claude/skills/{name}/SKILL.md` |
 
+Claude Code also supports project-scope skills at `.claude/skills/{name}/SKILL.md`, but these are not currently managed by Observal.
 ---
 
 ## MCP servers
@@ -154,7 +153,7 @@ Claude Code project MCP configuration is stored in:
 
 Observal can discover MCP servers from this configuration and supports both command-based and URL-based MCP configurations.
 
-When an agent contains MCP servers, `observal agent pull` generates the corresponding Claude Code MCP configuration.
+When an agent contains MCP servers, `observal pull` generates the corresponding Claude Code MCP configuration.
 
 ---
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,195 @@
+<!-- SPDX-FileCopyrightText: 2026 Rishika Kaur <kaurrishika377@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Claude Code
+
+Claude Code is a first-class Observal harness integration. Observal can install Claude Code agents, configure MCP servers, add hooks, expose skills, and collect session telemetry.
+
+---
+
+## Overview
+
+Claude Code agent profiles are Markdown files with YAML frontmatter. Project agents live in `.claude/agents/`. User agents live in `~/.claude/agents/`.
+
+Observal installs session push hooks into Claude Code's `settings.json`. The default hooks run the shared `observal_cli.hooks.session_push --harness claude-code` entry point for `UserPromptSubmit` and `Stop`.
+
+---
+
+## Supported capabilities
+
+| Capability      | Support                                                                 |
+| --------------- | ----------------------------------------------------------------------- |
+| Agent profiles  | Project and user scope                                                  |
+| Hook bridge     | `UserPromptSubmit` and `Stop` by default                                |
+| Custom hooks    | `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`     |
+| MCP servers     | `.mcp.json`                                                             |
+| Skills          | `.claude/skills/{name}/SKILL.md` and `~/.claude/skills/{name}/SKILL.md` |
+| Session parsing | Claude Code JSONL parser                                                |
+| Telemetry       | Session transcripts delivered through hooks and reconciliation          |
+
+---
+
+## Setup
+
+### 1. Install the Observal CLI
+
+```bash
+uv tool install observal-cli
+
+# or: pipx install observal-cli
+```
+
+### 2. Authenticate
+
+```bash
+observal auth login
+```
+
+This writes credentials to `~/.observal/config.json`.
+
+### 3. Pull an agent into Claude Code
+
+```bash
+observal agent pull <agent-name> --harness claude-code
+```
+
+Claude Code's default scope is project scope. By default, the agent is written to `.claude/agents/{name}.md`.
+
+To install into the current user's Claude Code configuration:
+
+```bash
+observal agent pull <agent-name> --harness claude-code --scope user
+```
+
+User agents are written to `~/.claude/agents/{name}.md`.
+
+---
+
+## Config paths
+
+| Purpose          | Project scope                    | User scope                         |
+| ---------------- | -------------------------------- | ---------------------------------- |
+| Agent profile    | `.claude/agents/{name}.md`       | `~/.claude/agents/{name}.md`       |
+| Skill definition | `.claude/skills/{name}/SKILL.md` | `~/.claude/skills/{name}/SKILL.md` |
+| Hook config      | `.claude/settings.json`          | `~/.claude/settings.json`          |
+| MCP config       | `.mcp.json`                      | —                                  |
+
+---
+
+## Hook spec
+
+Observal installs session push hooks for `UserPromptSubmit` and `Stop`.
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "command": "python -m observal_cli.hooks.session_push --harness claude-code"
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "python -m observal_cli.hooks.session_push --harness claude-code"
+      }
+    ]
+  }
+}
+```
+
+The Claude Code adapter recognizes `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, and `SubagentStop` hook events.
+
+---
+
+## Session push behavior
+
+Claude Code session data is stored as JSONL. Observal reads new session data incrementally and delivers it through the session ingestion endpoint.
+
+Sessions can also be pushed using:
+
+```bash
+observal reconcile
+```
+
+The session delivery system uses a local outbox and resumes after transient network failures.
+
+---
+
+## Agent profile format
+
+Observal generates Markdown agent profiles with YAML frontmatter:
+
+```markdown
+---
+name: my-agent
+model: claude-sonnet-4
+description: Agent description
+---
+
+Agent instructions go here.
+```
+
+---
+
+## Skill file format
+
+Claude Code skills live at:
+
+| Scope   | Path                               |
+| ------- | ---------------------------------- |
+| Project | `.claude/skills/{name}/SKILL.md`   |
+| User    | `~/.claude/skills/{name}/SKILL.md` |
+
+---
+
+## MCP servers
+
+Claude Code project MCP configuration is stored in:
+
+```text
+.mcp.json
+```
+
+Observal can discover MCP servers from this configuration and supports both command-based and URL-based MCP configurations.
+
+When an agent contains MCP servers, `observal agent pull` generates the corresponding Claude Code MCP configuration.
+
+---
+
+## Rules and guidance
+
+Claude Code supports guidance files such as:
+
+```text
+CLAUDE.md
+.claude/CLAUDE.md
+~/.claude/CLAUDE.md
+CLAUDE.local.md
+```
+
+These files provide instructions to Claude Code and are separate from Observal-managed agent profiles and skills.
+
+---
+
+## OTLP telemetry
+
+Observal does not require Claude Code OTLP environment variables for its telemetry integration.
+
+Do **not** configure:
+
+```text
+OTEL_*
+CLAUDE_CODE_ENABLE_TELEMETRY
+```
+
+for Observal's Claude Code integration.
+
+Instead, Observal's telemetry flow is based on session push hooks and `observal reconcile`, which deliver session data to the Observal ingestion endpoint.
+
+---
+
+## Caveats
+
+Claude Code supports both project and user scopes, with project scope as the default. MCP project configuration uses `.mcp.json`. Session delivery depends on Claude Code's local JSONL session data. Observal session telemetry uses session push and reconciliation rather than Claude Code OTLP environment variables.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Added `docs/integrations/claude-code.md` . The documentation covers Claude Code setup, overview, supported capabilities, configuration paths, hooks, session push behavior, MCP servers, skills, rules and guidance files, telemetry, and caveats.

## Fixes
* Fixes #1358 

## Approach
_Sourced directly from the implementation files rather than inferred. I verified the documented paths, event names, and behaviors against the current codebase:_

`packages/observal-cli/observal_cli/harness/claude_code.py` — Claude Code adapter, session discovery, MCP discovery, skills, agents, and hook detection
`packages/observal-cli/observal_cli/harness_specs/claude_code_hooks_spec.py` — hook specification and session-push hook configuration
`packages/observal-server/services/harness/claude_code.py` — agent configuration, MCP configuration, and hook generation
`packages/observal-shared/observal_shared/harness_registry.py` — configuration paths, supported scopes, capabilities, and hook events
`AGENTS.md` — CLI structure, telemetry approach, and project-specific development guidelines

_used `docs/integrations/kiro.md` and `docs/integrations/copilot.md` as references to follow the existing structure and style of Observal's integration documentation._

The page covers all sections required by the issue:
- Overview of the incremental session path architecture 
- Supported features table ( agents, skills, hooks, MCP)
- Setup steps
- config file paths for both  project and user scope 
- Hook spec (exact JSON written )
- Session push behavior 
- OTLP telemetry 
- Caveats 

## How Has This Been Tested?

Documentation only change. Verified no broken links and that all files paths, event names, and version constants match the current codebase.

Ran the repository pre-commit checks on the documentation file.

The applicable formatting, YAML/TOML/JSON, secrets, merge-conflict, and other checks passed.

The Alembic migration check and Dockerfile lint check were skipped because the required local Docker/Python environment was unavailable.

## Learning
Reviewed how Observal integrates with Claude Code through project and user configuration, session hooks, JSONL session data, MCP servers, skills, and reconciliation.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] Descriptive commit message
- [ ] You have commented your code 
- [x] Self-review completed
- [ ] UI changes ( N/A documentation only )

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Used GPT-5.6 Luna for understanding the codebase and reviewing relevant files.
- [x] Was the generated code manually reviewed and tested? Yes - the generated documentation was manually reviewed, and the relevant pre-commit checks were run before submission.

## Discord username (optional)

Discord username: _viciouss___


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for integrating Observal with Claude Code.
  - Documented agent installation, project and user configuration, session tracking, reconciliation, agent and skill formats, MCP setup, guidance files, telemetry behavior, and integration considerations.
  - Added details on session-push hooks, hook metadata and configuration, JSONL session ingestion, and the supported agent model.
  - Clarified that Observal-managed skills are user-scoped, while project-scoped skills remain supported by Claude Code but are not managed by Observal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->