### PR TITLE
fix(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,6 +530,9 @@ jobs:
     if: needs.tag.result == 'success'
     runs-on: ubuntu-latest
     environment: npm
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
@@ -538,7 +541,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Sync version from release
@@ -564,7 +567,6 @@ jobs:
         if: steps.published.outputs.already_published != 'true'
         env:
           CHANNEL: ${{ needs.preflight.outputs.channel }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd packages/pi-extension
           TAG="latest"


### PR DESCRIPTION
## Purpose / Description
Replace the failing long-lived npm token authentication in the release workflow with npm Trusted Publishing through GitHub OIDC.

## Fixes
* N/A

## Approach
- Grant the npm job permission to request an OIDC identity token.
- Use Node.js 24 so the bundled npm supports Trusted Publishing.
- Stop passing the legacy `NPM_TOKEN` to `npm publish`.

## How Has This Been Tested?

- `uvx --from pre-commit pre-commit run check-yaml --files .github/workflows/release.yml` passed.
- `SKIP=no-commit-to-branch uvx --from pre-commit pre-commit run --files .github/workflows/release.yml` passed.
- `make test` passed before the dependency bump: 8,539 passed and 21 skipped.
- The post-bump `make test` run was stopped at 99% at the maintainer's request, so it has no final result.
- The CI `pip-audit` command passed after the bump with no known vulnerabilities.
- `make check` was also attempted. It failed on pre-existing repository-wide checks for a fake private-key fixture and Dockerfile lint findings; unrelated end-of-file changes made by the hook were restored.
- A live npm publish was not run because it requires the merged workflow and creates an external release.

## Learning (optional, can help others)

- [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes(Please Specify the tool): Pi coding agent 0.85.0
- [x] Was the generated code manually reviewed and tested?

## Discord username (optional)

Discord username:
