### PR TITLE
fix(release): bundle harness model data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,9 @@ jobs:
         if: matrix.os == 'windows'
         run: mv dist/observal.exe dist/${{ matrix.artifact }}
 
+      - name: Smoke-test binary
+        run: ./dist/${{ matrix.artifact }} --version
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.artifact }}

--- a/observal_cli/pyinstaller.spec
+++ b/observal_cli/pyinstaller.spec
@@ -23,7 +23,12 @@ a = Analysis(
     [str(spec_dir / "main.py")],
     pathex=[str(repo_root)],
     binaries=[],
-    datas=[],
+    datas=[
+        (
+            str(repo_root / "packages" / "observal-shared" / "observal_shared" / "harness_models"),
+            "observal_shared/harness_models",
+        ),
+    ],
     hiddenimports=[
         "observal_cli.sandbox_runner",
         "typer",


### PR DESCRIPTION
## Purpose / Description
Fix standalone CLI binaries failing at startup because the generated harness model catalogs were absent from the PyInstaller bundle.

## Fixes
* N/A

## Approach
- Bundle `observal_shared/harness_models` as PyInstaller data.
- Run every platform binary with `--version` before uploading release artifacts so missing runtime data fails the build.

## How Has This Been Tested?

- Built the Linux x64 binary locally with Python 3.14 and PyInstaller 6.21.0.
- `./dist/observal --version` passed and returned `observal 1.13.0`.
- Targeted pre-commit checks passed.
- `make test` passed: 8,539 passed and 21 skipped.

## Learning (optional, can help others)

The v1.13.0 Linux binary had a valid checksum but failed before command dispatch with `FileNotFoundError` for `observal_shared/harness_models`.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes(Please Specify the tool): Pi coding agent 0.85.0
- [x] Was the generated code manually reviewed and tested?

## Discord username (optional)

Discord username:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI release reliability by verifying each built binary can run and report its version before publication.
  * Ensured packaged CLI builds include the required harness model resources for successful operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->