### PR TITLE
test: skip OpenCode strip-types test on Node < 22.6; align Node docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Please read our [Code of Conduct](https://github.com/Observal/Observal/blob/main
 
 * Docker and Docker Compose
 * [uv](https://docs.astral.sh/uv/) (Python 3.11+)
-* Node.js 20+ and pnpm (for the web frontend)
+* Node.js 22.6+ and pnpm (for the web frontend and `make test`; matches `package.json` `engines` and `--experimental-strip-types`)
 * Git
 
 ### Fork and Clone

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -88,7 +88,7 @@ Maintainers volunteer their time. Treat them accordingly.
 | ------- | ------------------- | ------------------------------------------------------------------------- |
 | Docker  | 24+ with Compose v2 | [docs.docker.com](https://docs.docker.com/get-docker/)                    |
 | uv      | latest              | `curl -LsSf https://astral.sh/uv/install.sh \| sh`                        |
-| Node.js | 20+                 | Via [nvm](https://github.com/nvm-sh/nvm) or [mise](https://mise.jdx.dev/) |
+| Node.js | 22.6+               | Via [nvm](https://github.com/nvm-sh/nvm) or [mise](https://mise.jdx.dev/) |
 | pnpm    | 10+                 | `npm install -g pnpm`                                                     |
 | Git     | 2.28+               | [git-scm.com](https://git-scm.com/)                                       |
 

--- a/tests/test_opencode_session_delivery.py
+++ b/tests/test_opencode_session_delivery.py
@@ -4,13 +4,40 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from typing import TYPE_CHECKING
+
+import pytest
 
 from observal_shared.opencode_plugin_source import OPENCODE_PLUGIN_SOURCE, OPENCODE_PLUGIN_VERSION
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _node_supports_strip_types() -> tuple[bool, str]:
+    """Return whether `node --experimental-strip-types` can run on this machine."""
+    try:
+        version_output = subprocess.run(
+            ["node", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False, "node executable not found"
+    if version_output.returncode != 0:
+        return False, f"node --version failed: {version_output.stderr.strip()}"
+    match = re.search(r"v(\d+)\.(\d+)", version_output.stdout)
+    if not match:
+        return False, f"could not parse node version from {version_output.stdout.strip()!r}"
+    major, minor = int(match.group(1)), int(match.group(2))
+    # --experimental-strip-types landed in Node 22.6.0 (package.json engines).
+    if (major, minor) < (22, 6):
+        return False, f"requires Node >= 22.6 for --experimental-strip-types (found {version_output.stdout.strip()})"
+    return True, ""
 
 
 def test_generated_plugin_uses_durable_acknowledged_delivery():
@@ -23,6 +50,9 @@ def test_generated_plugin_uses_durable_acknowledged_delivery():
 
 
 def test_native_outbox_survives_restart_and_clears_only_after_ack(tmp_path: Path):
+    supported, reason = _node_supports_strip_types()
+    if not supported:
+        pytest.skip(reason)
     plugin = tmp_path / "plugin.ts"
     plugin.write_text(
         OPENCODE_PLUGIN_SOURCE


### PR DESCRIPTION
## Problem

As reported in #1712: `package.json` already requires `node >= 22.6.0` (and `make test` / the OpenCode outbox test shell out to `node --experimental-strip-types`), but `CONTRIBUTING.md` and `docs/DEVELOPMENT_GUIDE.md` still document **Node.js 20+**. Contributors who follow the docs hit:

`
AssertionError: node: bad option: --experimental-strip-types
assert 9 == 0
`

## Changes

1. **Skip with a clear reason** when `node` is missing or older than 22.6.0 in `tests/test_opencode_session_delivery.py` (helper `_node_supports_strip_types`).
2. **Raise the documented floor** to Node **22.6+** in `CONTRIBUTING.md` and `docs/DEVELOPMENT_GUIDE.md` so they match `package.json` `engines`.

## Verification

- Node **18.19.0**: `1 passed, 1 skipped` with  
  `SKIPPED ... requires Node >= 22.6 for --experimental-strip-types (found v18.19.0)`
- Node **24.15.0**: the skip does not trigger (correct). The native runner body then runs; on this Windows machine it still fails an unrelated assertion (`666 !== 600`) that is **out of scope** for this docs/skip fix and does not reproduce the `--experimental-strip-types` error from #1712.

`
pytest tests/test_opencode_session_delivery.py -q -rs
`

## AI assistance disclosure

Per `AI_POLICY.md`: drafted with an interactive coding agent (MiMo / Claude-class assistant) under human direction; the human author reviewed the full diff, owns the change, and is able to explain every line. Tool: **MiMo Desktop agent**.

Fixes #1712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development prerequisites to Node.js 22.6 or later.
  * Clarified that pnpm is required for the web frontend and test commands.

* **Tests**
  * Added environment checks so a Node-dependent test is skipped when Node.js 22.6+ or type-stripping support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->