### PR TITLE
feat: allow anonymous public registry access

### DIFF
--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -109,6 +109,18 @@ _PASSWORD_CHANGE_EXEMPT_PATHS = frozenset(
 )
 
 
+async def _enforce_password_change(request: Request, user: User) -> None:
+    """Block authenticated requests until a required password change is complete."""
+    if request.url.path in _PASSWORD_CHANGE_EXEMPT_PATHS:
+        return
+    try:
+        redis = get_redis()
+        if await redis.get(f"must_change_password:{user.id}"):
+            raise HTTPException(status_code=403, detail="Password change required")
+    except RedisError:
+        raise HTTPException(status_code=503, detail="Auth service temporarily unavailable")
+
+
 async def get_current_user(
     request: Request,
     authorization: str | None = Header(None),
@@ -131,15 +143,8 @@ async def get_current_user(
     # Expose user to audit middleware
     request.state.audit_user = user
 
-    # Enforce must_change_password - fail closed: if Redis is down we cannot
-    # guarantee the gate is enforced, so block non-exempt requests.
-    if request.url.path not in _PASSWORD_CHANGE_EXEMPT_PATHS:
-        try:
-            redis = get_redis()
-            if await redis.get(f"must_change_password:{user.id}"):
-                raise HTTPException(status_code=403, detail="Password change required")
-        except RedisError:
-            raise HTTPException(status_code=503, detail="Auth service temporarily unavailable")
+    # Fail closed when a required password change cannot be verified.
+    await _enforce_password_change(request, user)
 
     request.state.current_user = user
     return user
@@ -163,6 +168,22 @@ async def optional_current_user(
     if user.auth_provider == "deactivated":
         raise HTTPException(status_code=401, detail="Account deactivated")
     return user
+
+
+async def get_registry_user(
+    request: Request,
+    current_user: User | None = Depends(optional_current_user),
+) -> User | None:
+    """Authorize registry reads, allowing guests only when public access is enabled."""
+    if current_user is None:
+        if not await ds.get_bool("deployment.public_registry_enabled"):
+            raise HTTPException(status_code=401, detail="Authentication required")
+        return None
+
+    request.state.audit_user = current_user
+    await _enforce_password_change(request, current_user)
+    request.state.current_user = current_user
+    return current_user
 
 
 # Role hierarchy: lower number = higher privilege

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -17,6 +17,7 @@ from api.deps import (
     apply_registry_scope,
     get_db,
     get_effective_agent_permission,
+    get_registry_user,
     require_role,
 )
 from api.search import keyword_search
@@ -263,7 +264,7 @@ async def list_agents(
     limit: int = Query(50, ge=1, le=200, description="Page size (1-200)"),
     offset: int = Query(0, ge=0, description="Items to skip"),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("listing agents")
     from models.feedback import Feedback
@@ -363,7 +364,7 @@ async def list_agents(
             average_rating=rating_map.get(a.id),
             component_count=len(a.components),
             created_by=a.created_by,
-            created_by_email=email_map.get(a.created_by, ""),
+            created_by_email=email_map.get(a.created_by, "") if current_user else "",
             created_by_username=username_map.get(a.created_by),
             created_at=a.created_at,
             updated_at=a.updated_at,
@@ -562,13 +563,13 @@ async def deleted_agents(
 async def get_agent(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("fetching agent details")
     agent = await _load_agent(
         db,
         agent_id,
-        prefer_user_id=current_user.id,
+        prefer_user_id=current_user.id if current_user else None,
         current_user=current_user,
     )
     if not agent:
@@ -583,7 +584,7 @@ async def get_agent(
     return _agent_to_response(
         agent,
         name_map,
-        created_by_email=user_row[0] if user_row else "",
+        created_by_email=user_row[0] if user_row and current_user else "",
         created_by_username=user_row[1] if user_row else None,
         user_permission=perm,
         status_map=status_map,

--- a/observal-server/api/routes/agent/install.py
+++ b/observal-server/api/routes/agent/install.py
@@ -15,7 +15,7 @@ from api.deps import (
     apply_visibility_filter,
     get_db,
     get_effective_agent_permission,
-    optional_current_user,
+    get_registry_user,
     require_role,
 )
 from api.routes._component_archive import archived_install_warning
@@ -46,19 +46,21 @@ async def install_agent(
     req: AgentInstallRequest,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("installing agent")
     agent = await _load_agent(
         db,
         agent_id,
-        prefer_user_id=current_user.id,
+        prefer_user_id=current_user.id if current_user else None,
         current_user=current_user,
     )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.status != AgentStatus.approved and not (
-        _ds.get_sync_bool("security.allow_draft_install") and agent.created_by == current_user.id
+        current_user is not None
+        and _ds.get_sync_bool("security.allow_draft_install")
+        and agent.created_by == current_user.id
     ):
         raise HTTPException(status_code=404, detail="Agent not found or not approved for installation")
     if get_effective_agent_permission(agent, current_user) == "none":
@@ -312,27 +314,28 @@ async def install_agent(
     # instance (e.g. savepoint rollback on duplicate download).
     resolved_agent_id = agent.id
 
-    from services.download_tracker import record_agent_download
+    if current_user is not None:
+        from services.download_tracker import record_agent_download
 
-    await record_agent_download(
-        agent_id=resolved_agent_id,
-        user_id=current_user.id,
-        source="api",
-        harness=req.harness,
-        request=request,
-        db=db,
-    )
-    await db.commit()
+        await record_agent_download(
+            agent_id=resolved_agent_id,
+            user_id=current_user.id,
+            source="api",
+            harness=req.harness,
+            request=request,
+            db=db,
+        )
+        await db.commit()
 
-    emit_registry_event(
-        action="agent.install",
-        user_id=str(current_user.id),
-        user_email=current_user.email,
-        user_role=current_user.role.value,
-        agent_id=str(resolved_agent_id),
-        resource_name=agent.name,
-        metadata={"harness": req.harness},
-    )
+        emit_registry_event(
+            action="agent.install",
+            user_id=str(current_user.id),
+            user_email=current_user.email,
+            user_role=current_user.role.value,
+            agent_id=str(resolved_agent_id),
+            resource_name=agent.name,
+            metadata={"harness": req.harness},
+        )
 
     warnings = archived_warnings + setup_warnings + snippet.pop("_warnings", [])
     return AgentInstallResponse(
@@ -344,13 +347,13 @@ async def install_agent(
 async def agent_download_stats(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("agent_id={}", agent_id)
     agent = await _load_agent(
         db,
         agent_id,
-        prefer_user_id=current_user.id if current_user else None,
+        prefer_user_id=current_user.id,
         current_user=current_user,
     )
     if not agent:
@@ -369,14 +372,14 @@ async def get_agent_traces(
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Return all traces where this agent participated."""
     optic.trace("agent_id={}, limit={}", agent_id, limit)
     agent = await _load_agent(
         db,
         agent_id,
-        prefer_user_id=current_user.id if current_user else None,
+        prefer_user_id=current_user.id,
         current_user=current_user,
     )
     if not agent:
@@ -390,11 +393,16 @@ async def get_agent_traces(
 async def resolve_agent_components(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     """Resolve all components for an agent - validates they exist and are approved."""
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id if current_user else None,
+        current_user=current_user,
+    )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
@@ -411,11 +419,16 @@ async def resolve_agent_components(
 async def get_agent_manifest(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     """Generate a portable agent manifest with all resolved components."""
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id if current_user else None,
+        current_user=current_user,
+    )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 from api.deps import (
     get_db,
     get_effective_agent_permission,
+    get_registry_user,
     may_view_unapproved,
     require_role,
 )
@@ -144,7 +145,7 @@ async def _list_agent_versions(
     page: int,
     page_size: int,
     db: AsyncSession,
-    current_user: User,
+    current_user: User | None,
 ) -> dict:
     optic.trace("agent_id={}, page={}", agent_id, page)
     agent = await _load_agent(db, agent_id, current_user)
@@ -174,7 +175,7 @@ async def _list_agent_versions(
     result = await db.execute(stmt)
     versions = result.scalars().all()
 
-    count_stmt = select(func.count(AgentVersion.id)).where(AgentVersion.agent_id == agent.id)
+    count_stmt = select(func.count(AgentVersion.id)).where(*version_filters)
     total = (await db.execute(count_stmt)).scalar() or 0
 
     return {
@@ -189,7 +190,7 @@ async def _get_agent_version(
     agent_id: str,
     version: str,
     db: AsyncSession,
-    current_user: User,
+    current_user: User | None,
 ) -> dict:
     optic.trace("agent_id={}, version={}", agent_id, version)
     agent = await _load_agent(db, agent_id, current_user)
@@ -495,7 +496,7 @@ async def _get_agent_harness_config(
     version: str,
     harness: str,
     db: AsyncSession,
-    current_user: User,
+    current_user: User | None,
 ) -> dict:
     optic.trace("agent_id={}, version={}", agent_id, version)
     agent = await _load_agent(db, agent_id, current_user)
@@ -534,7 +535,7 @@ async def _get_version_diff(
     v1: str,
     v2: str,
     db: AsyncSession,
-    current_user: User,
+    current_user: User | None,
 ) -> dict:
     optic.trace("agent_id={}, v1={}", agent_id, v1)
     agent = await _load_agent(db, agent_id, current_user)
@@ -638,7 +639,7 @@ async def list_agent_versions(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("agent versions list")
     return await _list_agent_versions(
@@ -655,7 +656,7 @@ async def get_agent_version(
     agent_id: str,
     version: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.trace("agent_id={}, version={}", agent_id, version)
     return await _get_agent_version(
@@ -706,7 +707,7 @@ async def get_agent_harness_config(
     version: str,
     harness: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.trace("agent_id={}, version={}", agent_id, version)
     return await _get_agent_harness_config(
@@ -724,7 +725,7 @@ async def get_version_diff(
     v1: str,
     v2: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.trace("agent_id={}, v1={}", agent_id, v1)
     return await _get_version_diff(

--- a/observal-server/api/routes/component_versions.py
+++ b/observal-server/api/routes/component_versions.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 from api.deps import (
     get_db,
     get_effective_component_permission,
+    get_registry_user,
     may_view_unapproved,
     require_role,
     resolve_visible_listing,
@@ -103,7 +104,7 @@ async def _list_versions(
     version_model,
     component_type: str,
     db: AsyncSession,
-    current_user: User,
+    current_user: User | None,
 ) -> dict:
     optic.trace("listing_id={}, page={}", listing_id, page)
     listing = await resolve_visible_listing(listing_model, listing_id, db, current_user)
@@ -149,7 +150,7 @@ async def _get_version(
     version_model,
     component_type: str,
     db: AsyncSession,
-    current_user: User,
+    current_user: User | None,
 ) -> dict:
     optic.trace("listing_id={}, version={}", listing_id, version)
     listing = await resolve_visible_listing(listing_model, listing_id, db, current_user)
@@ -365,7 +366,7 @@ def create_version_router(
         page: int = Query(1, ge=1),
         page_size: int = Query(20, ge=1, le=100),
         db: AsyncSession = Depends(get_db),
-        current_user: User = Depends(require_role(UserRole.user)),
+        current_user: User | None = Depends(get_registry_user),
     ):
         optic.trace("listing_id={}, page={}", listing_id, page)
         return await _list_versions(
@@ -384,7 +385,7 @@ def create_version_router(
         listing_id: str,
         version: str,
         db: AsyncSession = Depends(get_db),
-        current_user: User = Depends(require_role(UserRole.user)),
+        current_user: User | None = Depends(get_registry_user),
     ):
         optic.trace("listing_id={}, version={}", listing_id, version)
         return await _get_version(

--- a/observal-server/api/routes/config.py
+++ b/observal-server/api/routes/config.py
@@ -147,6 +147,7 @@ async def get_public_config(db=Depends(get_db)):
     exec_dashboard_available = True
 
     sso_only = await ds.get_bool("deployment.sso_only")
+    public_registry_enabled = await ds.get_bool("deployment.public_registry_enabled")
     self_registration_enabled = await ds.get_bool("auth.self_registration_enabled")
 
     from api.routes.auth import is_github_oauth_configured, is_google_oauth_configured, is_oidc_configured
@@ -159,6 +160,7 @@ async def get_public_config(db=Depends(get_db)):
         "google_sso_enabled": is_google_oauth_configured(),
         "github_sso_enabled": is_github_oauth_configured(),
         "sso_only": sso_only,
+        "public_registry_enabled": public_registry_enabled,
         "self_registration_enabled": self_registration_enabled,
         "saml_enabled": saml_enabled,
         "exec_dashboard_available": exec_dashboard_available,

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -18,7 +18,7 @@ from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 
-from api.deps import apply_visibility_filter, get_db, optional_current_user, require_role
+from api.deps import apply_visibility_filter, get_db, get_registry_user, require_role
 from api.sanitize import escape_like
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.agent_component import AgentComponent
@@ -76,7 +76,7 @@ async def _ch_json(sql: str, params: dict | None = None) -> list[dict]:
 async def overview_stats(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
 
     optic.trace("range={}", range_)
@@ -126,7 +126,7 @@ async def overview_stats(
 @router.get("/overview/top-mcps", response_model=list[TopItem])
 async def top_mcps(
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("top_mcps called")
     stmt = select(McpDownload.listing_id, func.count(McpDownload.id).label("cnt"), McpListing.name).join(
@@ -142,7 +142,7 @@ async def top_mcps(
 async def top_agents(
     limit: int = Query(6, le=50),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     stmt = (
         select(
@@ -210,7 +210,7 @@ async def agent_leaderboard(
     limit: int = Query(20, le=50),
     user: str | None = Query(None, description="Filter by creator email"),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     """Public leaderboard of agents ranked by downloads within a time window."""
     stmt = (
@@ -230,7 +230,7 @@ async def agent_leaderboard(
         .where(AgentVersion.status == AgentStatus.approved, Agent.deleted_at.is_(None))
     )
     stmt = apply_visibility_filter(stmt, Agent, current_user)
-    if user:
+    if user and current_user is not None:
         stmt = stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{escape_like(user)}%"))
     if window != "all":
         days = _RANGE_MAP.get(window, 7)
@@ -281,7 +281,7 @@ async def agent_leaderboard(
             )
         )
         extra_stmt = apply_visibility_filter(extra_stmt, Agent, current_user)
-        if user:
+        if user and current_user is not None:
             extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(
                 User.email.ilike(f"%{escape_like(user)}%")
             )
@@ -307,7 +307,7 @@ async def agent_leaderboard(
                 version=a.version or "",
                 download_count=0,
                 average_rating=rating_map.get(a.id),
-                created_by_email=email_map.get(a.created_by, ""),
+                created_by_email=email_map.get(a.created_by, "") if current_user else "",
                 created_by_username=username_map.get(a.created_by),
             )
             for a in extra
@@ -327,7 +327,7 @@ async def agent_leaderboard(
             version=row.version or "",
             download_count=row.cnt,
             average_rating=rating_map.get(row.agent_id),
-            created_by_email=email_map.get(row.created_by, ""),
+            created_by_email=email_map.get(row.created_by, "") if current_user else "",
             created_by_username=username_map.get(row.created_by),
         )
         for row in rows
@@ -340,7 +340,7 @@ async def component_leaderboard(
     limit: int = Query(20, le=50),
     user: str | None = Query(None, description="Filter by creator email"),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     """Public leaderboard of components ranked by agent downloads within a time window."""
     listing_types = [
@@ -381,7 +381,7 @@ async def component_leaderboard(
         )
         stmt = apply_visibility_filter(stmt, Agent, current_user)
         stmt = apply_visibility_filter(stmt, listing_model, current_user)
-        if user:
+        if user and current_user is not None:
             stmt = stmt.join(User, listing_model.submitted_by == User.id).where(
                 User.email.ilike(f"%{escape_like(user)}%")
             )
@@ -439,7 +439,7 @@ async def component_leaderboard(
 
     # Resolve user emails
     email_map: dict[uuid.UUID, str] = {}
-    if all_user_ids:
+    if all_user_ids and current_user is not None:
         email_rows = await db.execute(select(User.id, User.email).where(User.id.in_(all_user_ids)))
         email_map = {r[0]: r[1] for r in email_rows.all()}
 
@@ -450,7 +450,7 @@ async def component_leaderboard(
         item.total_reviews = total_reviews
     for item in all_items:
         uid = submitted_by_map.get(item.id)
-        if uid and not item.created_by_email:
+        if uid and current_user is not None and not item.created_by_email:
             item.created_by_email = email_map.get(uid, "")
 
     # Backfill: include approved components with zero agent downloads
@@ -475,7 +475,7 @@ async def component_leaderboard(
             extra_stmt = extra_stmt.order_by(listing_model.created_at.desc()).limit(limit - len(all_items))
             extra_rows = (await db.execute(extra_stmt)).all()
             extra_sub_ids = {r.submitted_by for r in extra_rows if r.submitted_by} - set(email_map)
-            if extra_sub_ids:
+            if extra_sub_ids and current_user is not None:
                 for er in (await db.execute(select(User.id, User.email).where(User.id.in_(extra_sub_ids)))).all():
                     email_map[er[0]] = er[1]
             for r in extra_rows:
@@ -493,7 +493,7 @@ async def component_leaderboard(
                         component_type=type_label,
                         description=r.description or "",
                         download_count=0,
-                        created_by_email=email_map.get(r.submitted_by, "") if r.submitted_by else "",
+                        created_by_email=(email_map.get(r.submitted_by, "") if r.submitted_by and current_user else ""),
                         average_rating=avg_rating,
                         total_reviews=total_reviews,
                     )

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -15,7 +15,7 @@ from api.deps import (
     apply_visibility_filter,
     check_listing_visibility_async,
     get_db,
-    optional_current_user,
+    get_registry_user,
     require_role,
 )
 from models.agent import Agent
@@ -228,7 +228,7 @@ async def my_feedback_received(
 async def feedback_summary(
     listing_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.trace("listing_id={}", listing_id)
     await _visible_listing_by_id(db, listing_id, current_user)
@@ -251,7 +251,7 @@ async def get_feedback(
     listing_type: str,
     listing_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     """Get all reviews for a listing. Anonymous reviews have user_id redacted."""
     optic.trace("listing_type={}, listing_id={}", listing_type, listing_id)

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -19,8 +19,8 @@ from api.deps import (
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    get_registry_user,
     may_view_unapproved,
-    optional_current_user,
     require_role,
     resolve_listing,
     resolve_visible_listing,
@@ -134,7 +134,7 @@ async def list_hooks(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("hook list: search={}", search)
     stmt = (
@@ -206,7 +206,7 @@ async def my_hooks(
 async def get_hook(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("hook get: listing_id={}", listing_id)
     listing = await resolve_visible_listing(
@@ -230,7 +230,7 @@ async def install_hook(
     req: HookInstallRequest,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("hook install: listing_id={}", listing_id)
     listing = await resolve_visible_listing(
@@ -238,7 +238,7 @@ async def install_hook(
     )
     if not listing:
         listing = await resolve_visible_listing(HookListing, listing_id, db, current_user)
-        if not listing:
+        if not listing or current_user is None:
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
         if (
             listing.status != ListingStatus.archived
@@ -250,11 +250,12 @@ async def install_hook(
     if listing.status == ListingStatus.archived:
         warnings.append(archived_install_warning("hook", listing.name))
 
-    db.add(HookDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
-    latest_version = getattr(listing, "latest_version", None)
-    if latest_version:
-        latest_version.download_count += 1
-    await commit_or_name_conflict(db, "hook")
+    if current_user is not None:
+        db.add(HookDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
+        latest_version = getattr(listing, "latest_version", None)
+        if latest_version:
+            latest_version.download_count += 1
+        await commit_or_name_conflict(db, "hook")
 
     from services.hook_install_generator import generate_hook_install_config
 

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -19,8 +19,8 @@ from api.deps import (
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    get_registry_user,
     may_view_unapproved,
-    optional_current_user,
     require_role,
     resolve_listing,
     resolve_visible_listing,
@@ -234,7 +234,7 @@ async def list_mcps(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("mcp list: search={}", search)
     stmt = (
@@ -302,7 +302,7 @@ async def my_mcps(
 async def get_mcp(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("mcp get: listing_id={}", listing_id)
     listing = await resolve_visible_listing(
@@ -326,7 +326,7 @@ async def install_mcp(
     req: McpInstallRequest,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("mcp install: listing_id={}", listing_id)
     listing = await resolve_visible_listing(
@@ -334,9 +334,13 @@ async def install_mcp(
     )
     if not listing:
         listing = await resolve_visible_listing(McpListing, listing_id, db, current_user)
-        if not listing or (
-            listing.status != ListingStatus.archived
-            and get_effective_component_permission(listing, current_user) != "owner"
+        if (
+            not listing
+            or current_user is None
+            or (
+                listing.status != ListingStatus.archived
+                and get_effective_component_permission(listing, current_user) != "owner"
+            )
         ):
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
 
@@ -346,11 +350,12 @@ async def install_mcp(
     if listing.setup_instructions:
         warnings.append(f"MCP '{listing.name}' requires local setup before use:\n{listing.setup_instructions}")
 
-    db.add(McpDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
-    latest_version = getattr(listing, "latest_version", None)
-    if latest_version:
-        latest_version.download_count += 1
-    await commit_or_name_conflict(db, "listing")
+    if current_user is not None:
+        db.add(McpDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
+        latest_version = getattr(listing, "latest_version", None)
+        if latest_version:
+            latest_version.download_count += 1
+        await commit_or_name_conflict(db, "listing")
 
     from api.routes.config import derive_endpoints
 

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -19,8 +19,8 @@ from api.deps import (
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    get_registry_user,
     may_view_unapproved,
-    optional_current_user,
     require_role,
     resolve_listing,
     resolve_visible_listing,
@@ -46,6 +46,7 @@ from services.registry_namespace import identity_exists
 from services.teamspace import publish_auto_approves_for_entity, resolve_publish_target
 
 router = APIRouter(prefix="/api/v1/prompts", tags=["prompts"])
+_PROMPT_VARIABLE_RE = re.compile(r"\{\{\s*([^{}\r\n]*?\S)\s*\}\}")
 
 
 @router.post("/submit", response_model=PromptListingResponse)
@@ -124,7 +125,7 @@ async def list_prompts(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("prompt list: search={}", search)
     stmt = (
@@ -195,7 +196,7 @@ async def my_prompts(
 async def get_prompt(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("prompt get: listing_id={}", listing_id)
     listing = await resolve_visible_listing(
@@ -218,7 +219,7 @@ async def render_prompt(
     listing_id: str,
     req: PromptRenderRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("prompt render")
     listing = await resolve_visible_listing(
@@ -226,15 +227,21 @@ async def render_prompt(
     )
     if not listing:
         listing = await resolve_visible_listing(PromptListing, listing_id, db, current_user)
-        if not listing or (
-            listing.status != ListingStatus.archived
-            and get_effective_component_permission(listing, current_user) != "owner"
+        if (
+            not listing
+            or current_user is None
+            or (
+                listing.status != ListingStatus.archived
+                and get_effective_component_permission(listing, current_user) != "owner"
+            )
         ):
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
 
-    rendered = listing.template
-    for key, value in req.variables.items():
-        rendered = re.sub(r"\{\{\s*" + re.escape(key) + r"\s*\}\}", value, rendered)
+    def replace_variable(match: re.Match[str]) -> str:
+        key = match.group(1)
+        return req.variables[key] if key in req.variables else match.group(0)
+
+    rendered = _PROMPT_VARIABLE_RE.sub(replace_variable, listing.template)
 
     return PromptRenderResponse(listing_id=listing.id, rendered=rendered)
 

--- a/observal-server/api/routes/registry.py
+++ b/observal-server/api/routes/registry.py
@@ -20,8 +20,8 @@ from api.deps import (
     get_db,
     get_effective_agent_permission,
     get_effective_component_permission,
+    get_registry_user,
     may_view_unapproved,
-    optional_current_user,
     resolve_listing,
     resolve_visible_listing,
 )
@@ -99,7 +99,7 @@ async def resolve_registry_identifier(
     type: str = Query(..., pattern="^(agent|mcp|skill|hook|prompt|sandbox)$"),
     identifier: str = Query(..., min_length=1, max_length=129),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     """Resolve a canonical or legacy registry reference without exposing hidden listings."""
     if type == "agent":

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -18,8 +18,8 @@ from api.deps import (
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    get_registry_user,
     may_view_unapproved,
-    optional_current_user,
     require_role,
     resolve_listing,
     resolve_visible_listing,
@@ -125,7 +125,7 @@ async def list_sandboxes(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("sandbox list: search={}", search)
     stmt = (
@@ -197,7 +197,7 @@ async def my_sandboxes(
 async def get_sandbox(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("sandbox get: listing_id={}", listing_id)
     listing = await resolve_visible_listing(

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -20,8 +20,8 @@ from api.deps import (
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    get_registry_user,
     may_view_unapproved,
-    optional_current_user,
     require_role,
     resolve_listing,
     resolve_visible_listing,
@@ -207,7 +207,7 @@ async def list_skills(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("listing skills (task_type={}, search={})", task_type, search)
     stmt = (
@@ -291,7 +291,7 @@ async def my_skills(
 async def get_skill(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(optional_current_user),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("fetching skill {}", listing_id)
     listing = await resolve_visible_listing(
@@ -315,7 +315,7 @@ async def install_skill(
     req: SkillInstallRequest,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User | None = Depends(get_registry_user),
 ):
     optic.debug("installing skill {}", listing_id)
     listing = await resolve_visible_listing(
@@ -323,7 +323,7 @@ async def install_skill(
     )
     if not listing:
         listing = await resolve_visible_listing(SkillListing, listing_id, db, current_user)
-        if not listing:
+        if not listing or current_user is None:
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
         if (
             listing.status != ListingStatus.archived
@@ -353,11 +353,12 @@ async def install_skill(
                 detail=f"Version {req.version!r} not found for this skill",
             )
 
-    db.add(SkillDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
-    latest_version = getattr(listing, "latest_version", None)
-    if latest_version:
-        latest_version.download_count += 1
-    await commit_or_name_conflict(db, "skill")
+    if current_user is not None:
+        db.add(SkillDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
+        latest_version = getattr(listing, "latest_version", None)
+        if latest_version:
+            latest_version.download_count += 1
+        await commit_or_name_conflict(db, "skill")
 
     from api.routes.config import derive_endpoints
     from services.skill_config_generator import generate_skill_config

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "email-validator",
     "alembic",
     "httpx",
-    "gitpython>=3.1.58",
+    "gitpython>=3.1.59",
     "boto3",
     "litellm>=1.80.0,<1.90.0",
     # Required by LiteLLM for the `vertex_ai/*` models the insights settings

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -324,6 +324,7 @@ DEFAULTS: dict[str, str] = {
     "github.allowed_orgs": "",
     # Deployment
     "deployment.sso_only": "false",
+    "deployment.public_registry_enabled": "false",
     "deployment.frontend_url": "http://localhost:3000",
     "deployment.public_url": "",
     "deployment.cors_origins": "http://localhost:3000",
@@ -406,6 +407,13 @@ SENSITIVE_KEYS: set[str] = {
 
 SETTING_FEATURES: dict[str, str] = {}
 
+SETTING_SUBTITLES: dict[str, str] = {
+    "deployment.public_registry_enabled": (
+        "Allow signed-out visitors to browse and install approved public registry content. "
+        "Publishing, private data, telemetry, and administration still require authentication."
+    ),
+}
+
 RESTART_REQUIRED_KEYS: set[str] = {
     "oauth.client_id",
     "oauth.client_secret",
@@ -458,7 +466,7 @@ def settings_schema() -> list[dict[str, Any]]:
                 {
                     "key": key,
                     "label": _setting_label(key),
-                    "subtitle": "",
+                    "subtitle": SETTING_SUBTITLES.get(key, ""),
                     "default": DEFAULTS.get(key, ""),
                     "requires_feature": SETTING_FEATURES.get(key) or section.get("requires_feature"),
                     "restart_required": key in RESTART_REQUIRED_KEYS,

--- a/observal-server/tests/test_agent_pull.py
+++ b/observal-server/tests/test_agent_pull.py
@@ -355,3 +355,39 @@ async def test_install_agent_with_approved_version_succeeds():
     assert result.agent_id == agent.id
     assert result.harness == "claude-code"
     assert isinstance(result.config_snippet, dict)
+
+
+@pytest.mark.asyncio
+async def test_anonymous_agent_install_does_not_record_download_metrics():
+    """Guests can install approved agents without mutating download metrics."""
+    from api.routes.agent.install import install_agent
+    from schemas.agent import AgentInstallRequest
+
+    agent = _make_agent(with_approved_version=True)
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.scheme = "http"
+    request.url.hostname = "localhost"
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(all=lambda: []))))
+    db.commit = AsyncMock()
+    record_download = AsyncMock()
+
+    with (
+        patch("api.routes.agent.install._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.install.get_effective_agent_permission", return_value="view"),
+        patch("api.routes.agent.install.generate_agent_config", return_value={"mcpServers": {}}),
+        patch("api.routes.config.derive_endpoints", return_value={"api": "http://localhost:8000", "otlp_http": ""}),
+        patch("services.download_tracker.record_agent_download", new=record_download),
+    ):
+        result = await install_agent(
+            agent_id=str(agent.id),
+            req=AgentInstallRequest(harness="claude-code"),
+            request=request,
+            db=db,
+            current_user=None,
+        )
+
+    assert result.agent_id == agent.id
+    record_download.assert_not_awaited()
+    db.commit.assert_not_awaited()

--- a/observal-server/tests/test_agent_versions_api.py
+++ b/observal-server/tests/test_agent_versions_api.py
@@ -172,6 +172,29 @@ async def test_list_versions_with_data():
 
 
 @pytest.mark.asyncio
+async def test_anonymous_version_count_only_includes_approved_versions():
+    """Anonymous pagination totals use the same approved-only filter as the rows."""
+    from api.routes.agent_versions import _list_agent_versions
+
+    agent = _make_agent()
+    db = _db_returning_versions([], total=0)
+
+    with patch("api.routes.agent_versions._load_agent", new=AsyncMock(return_value=agent)):
+        await _list_agent_versions(
+            agent_id=str(agent.id),
+            page=1,
+            page_size=20,
+            db=db,
+            current_user=None,
+        )
+
+    list_statement = db.execute.await_args_list[0].args[0]
+    count_statement = db.execute.await_args_list[1].args[0]
+    assert "agent_versions.status" in str(list_statement)
+    assert "agent_versions.status" in str(count_statement)
+
+
+@pytest.mark.asyncio
 async def test_list_versions_pagination():
     """list_agent_versions respects page/page_size parameters."""
     from api.routes.agent_versions import _list_agent_versions

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -862,14 +862,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/3ca813cbacb23ab6fe46ff38a9b5ef8e73e970c8051f2ce903aacafe0446/gitpython-3.1.62.tar.gz", hash = "sha256:1791de66309bc0c7cfca40bf8d2e3de7ca091cbf94e6051be1ad0722c61062af", size = 231728, upload-time = "2026-09-07T02:57:21.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0b/29d7965215f8ef830a7ca1f42997fe13e5693d85e9edb18f938d063ef5f2/gitpython-3.1.62-py3-none-any.whl", hash = "sha256:7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e", size = 222753, upload-time = "2026-09-07T02:57:19.762Z" },
 ]
 
 [[package]]
@@ -2066,7 +2066,7 @@ requires-dist = [
     { name = "email-validator" },
     { name = "fastapi", specifier = ">=0.136.0,!=0.136.3" },
     { name = "fastapi-cache2", specifier = ">=0.2.2" },
-    { name = "gitpython", specifier = ">=3.1.58" },
+    { name = "gitpython", specifier = ">=3.1.59" },
     { name = "google-cloud-aiplatform", specifier = ">=1.60.0" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.15" },

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -8,6 +8,7 @@
 import logging
 import time
 import uuid
+from contextvars import ContextVar
 from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
@@ -27,6 +28,8 @@ _version_enforced: bool = False
 
 # Subcommands exempt from version enforcement (user needs these to fix mismatches)
 _EXEMPT_SUBCOMMANDS = frozenset({"self", "server"})
+_OPTIONAL_AUTH = ContextVar("observal_optional_auth", default=False)
+_PUBLIC_POST = ContextVar("observal_public_post", default=False)
 
 
 def _get_cli_version() -> str:
@@ -40,12 +43,12 @@ def _get_cli_version() -> str:
 
 
 def _client() -> tuple[str, dict]:
-    cfg = config.get_or_exit()
+    auth_required = not _OPTIONAL_AUTH.get()
+    cfg = config.get_or_exit() if auth_required else config.get_or_exit(require_auth=False)
     base_url = cfg["server_url"].rstrip("/")
-    headers = {
-        "Authorization": f"Bearer {cfg['access_token']}",
-        "X-Observal-CLI-Version": _get_cli_version(),
-    }
+    headers = {"X-Observal-CLI-Version": _get_cli_version()}
+    if token := cfg.get("access_token"):
+        headers["Authorization"] = f"Bearer {token}"
     # Run version enforcement once per session (unless exempt subcommand)
     _enforce_version_once(base_url)
     return base_url, headers
@@ -397,8 +400,13 @@ def _request(
     resource: str,
     params: dict | None = None,
     json_data: object | None = None,
+    auth_required: bool = True,
 ) -> httpx.Response:
-    base, headers = _client()
+    optional_auth_token = _OPTIONAL_AUTH.set(not auth_required)
+    try:
+        base, headers = _client()
+    finally:
+        _OPTIONAL_AUTH.reset(optional_auth_token)
     request_kwargs: dict = {}
     if params is not None:
         request_kwargs["params"] = params
@@ -483,7 +491,14 @@ def get(
         default_operation=f"Fetch {path}",
         default_resource=path,
     )
-    response = _request("get", path, operation=operation, resource=resource, params=params)
+    response = _request(
+        "get",
+        path,
+        operation=operation,
+        resource=resource,
+        params=params,
+        auth_required=False,
+    )
     return _json_response(response, operation=operation, resource=resource)
 
 
@@ -503,7 +518,14 @@ def get_text(
         default_operation=f"Fetch {path}",
         default_resource=path,
     )
-    response = _request("get", path, operation=operation, resource=resource, params=params)
+    response = _request(
+        "get",
+        path,
+        operation=operation,
+        resource=resource,
+        params=params,
+        auth_required=False,
+    )
     actual_content_type = response.headers.get("content-type", "").lower()
     if content_type and content_type.lower() not in actual_content_type:
         fail(
@@ -533,7 +555,14 @@ def get_with_headers(
         default_operation=f"Fetch {path}",
         default_resource=path,
     )
-    response = _request("get", path, operation=operation, resource=resource, params=params)
+    response = _request(
+        "get",
+        path,
+        operation=operation,
+        resource=resource,
+        params=params,
+        auth_required=False,
+    )
     headers = {key.lower(): value for key, value in response.headers.items()}
     return _json_response(response, operation=operation, resource=resource), headers
 
@@ -552,8 +581,32 @@ def post(
         default_operation=f"Create or act on {path}",
         default_resource=path,
     )
-    response = _request("post", path, operation=operation, resource=resource, json_data=json_data)
+    response = _request(
+        "post",
+        path,
+        operation=operation,
+        resource=resource,
+        json_data=json_data,
+        auth_required=not _PUBLIC_POST.get(),
+    )
     return _json_response(response, operation=operation, resource=resource, allow_empty=True)
+
+
+def post_public(
+    path: str,
+    json_data: dict | None = None,
+    *,
+    operation: str | None = None,
+    resource: str | None = None,
+) -> dict:
+    """POST to a read-like public endpoint, using credentials when available."""
+    public_post_token = _PUBLIC_POST.set(True)
+    try:
+        if operation is None and resource is None:
+            return post(path, json_data)
+        return post(path, json_data, operation=operation, resource=resource)
+    finally:
+        _PUBLIC_POST.reset(public_post_token)
 
 
 def put(

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -952,7 +952,7 @@ def agent_install(
     harness = _validate_harnesses([harness], operation="Generate agent installation")[0]
     resolved = client.resolve_registry_reference("agent", agent_id)
     with _progress("json" if raw else output, f"Generating {harness} config..."):
-        result = client.post(f"/api/v1/agents/{resolved}/install", {"harness": harness})
+        result = client.post_public(f"/api/v1/agents/{resolved}/install", {"harness": harness})
 
     snippet = result.get("config_snippet", {})
     if raw:

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -639,6 +639,7 @@ def whoami(
         observal auth whoami
         observal auth whoami --output json
     """
+    config.get_or_exit()
     with nullcontext() if _is_json(output) else spinner("Checking..."):
         user = client.get("/api/v1/auth/whoami")
     if _is_json(output):

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -541,7 +541,7 @@ def hook_install(
     )
     install_context = nullcontext() if machine_output else spinner(f"Generating {harness} config...")
     with install_context:
-        result = client.post(
+        result = client.post_public(
             f"/api/v1/hooks/{resolved}/install",
             {"harness": harness, "platform": platform, "local_name": local_name},
         )

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1201,7 +1201,7 @@ def _install_impl(
         }
         if version:
             install_body["version"] = version
-        result = client.post(
+        result = client.post_public(
             f"/api/v1/mcps/{resolved}/install",
             install_body,
         )

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -398,7 +398,7 @@ def prompt_render(
         variables[key.strip()] = raw.strip("\"'")
     render_context = nullcontext() if output == "json" else spinner("Rendering prompt...")
     with render_context:
-        result = client.post(f"/api/v1/prompts/{resolved}/render", {"variables": variables})
+        result = client.post_public(f"/api/v1/prompts/{resolved}/render", {"variables": variables})
     if output == "json":
         output_json(result)
     else:

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -447,7 +447,7 @@ def _rewrite_kiro_hooks(content: dict, agent_id: str | None = None) -> dict:
 
     from observal_cli.harness_specs.kiro_hooks_spec import build_kiro_hooks
 
-    cfg = config.get_or_exit()
+    cfg = config.get_or_exit(require_auth=False)
     hooks_url = f"{cfg['server_url'].rstrip('/')}/api/v1/telemetry/hooks"
     desired_hooks = build_kiro_hooks(hooks_url, agent_id=agent_id or "")
 
@@ -919,7 +919,7 @@ def register_pull(app: typer.Typer):
             }
             if version:
                 install_body["version"] = version
-            result = client.post(
+            result = client.post_public(
                 f"/api/v1/agents/{resolved}/install",
                 install_body,
             )

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -681,7 +681,7 @@ def skill_install(
         install_body = {"harness": harness, "scope": scope, "local_name": local_name}
         if version:
             install_body["version"] = version
-        result = client.post(f"/api/v1/skills/{resolved}/install", install_body)
+        result = client.post_public(f"/api/v1/skills/{resolved}/install", install_body)
     snippet = result.get("config_snippet", result)
 
     if raw:

--- a/observal_cli/config.py
+++ b/observal_cli/config.py
@@ -39,6 +39,8 @@ _LEGACY_MCP_CONFIGS = (
     ".pi/mcp.json",
 )
 
+PUBLIC_SERVER_URL = "https://public.observal.io"
+
 DEFAULTS = {
     "server_url": "",
     "access_token": "",
@@ -277,15 +279,23 @@ def get_timeout() -> int:
     return int(cfg.get("timeout", 30))
 
 
-def get_or_exit() -> dict:
+def get_or_exit(*, require_auth: bool = True) -> dict:
     cfg = load()
-    if not cfg.get("server_url") or not cfg.get("access_token"):
+    if not cfg.get("server_url") and not require_auth and not cfg.get("access_token"):
+        cfg["server_url"] = PUBLIC_SERVER_URL
+    if not cfg.get("server_url") or (require_auth and not cfg.get("access_token")):
         fail(
-            ErrorCategory.AUTH,
-            "Not configured. Observal authentication is required.",
-            operation="Load authenticated CLI configuration",
+            ErrorCategory.AUTH if require_auth else ErrorCategory.USAGE,
+            "Not configured. Observal authentication is required."
+            if require_auth
+            else "No Observal server is configured.",
+            operation="Load authenticated CLI configuration" if require_auth else "Load CLI configuration",
             resource=str(CONFIG_FILE),
-            remediation="Run observal auth login or set OBSERVAL_TOKEN or OBSERVAL_ACCESS_TOKEN.",
+            remediation=(
+                "Run observal auth login or set OBSERVAL_TOKEN or OBSERVAL_ACCESS_TOKEN."
+                if require_auth
+                else "Set OBSERVAL_SERVER_URL or run observal config set server_url URL."
+            ),
         )
     return cfg
 

--- a/observal_cli/lockfile.py
+++ b/observal_cli/lockfile.py
@@ -55,7 +55,7 @@ def normalize_server_url(server_url: str) -> str:
 def current_registry_url() -> str:
     from observal_cli import config
 
-    return normalize_server_url(str(config.load().get("server_url") or ""))
+    return normalize_server_url(str(config.get_or_exit(require_auth=False)["server_url"]))
 
 
 def migrate_lockfile_v1(server_url: str | None = None) -> bool:

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -21,6 +21,7 @@ owner: observal
 7. Submit or modify only components the user owns or is authorized to manage.
 8. Never expose environment values, headers, tokens, private source data, or submitted secret fields.
 9. Mutations are sent once. After an uncertain transport failure, read component state before retrying.
+10. Authentication is optional for approved public content when the server setting `deployment.public_registry_enabled` is enabled; it is disabled by default on self-hosted deployments. Public list, show, install, and prompt render commands use `https://public.observal.io` by default. Authenticate before submitting, editing, reviewing, rating, or accessing private team content.
 
 ## Choose the workflow
 

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -25,6 +25,7 @@ Use this skill for core account, setup, local inventory, inbox, and teamspace wo
 8. Treat tokens, invitation URLs, credentials, generated passwords, headers, and environment values as secrets. Do not echo them.
 9. Fail openly. Do not silently switch to direct API calls, database access, or local file writes.
 10. Automatic transient retries apply only to reads. After an uncertain mutation failure, verify state before retrying.
+11. Public registry reads need no login when the server setting `deployment.public_registry_enabled` is enabled; it is disabled by default on self-hosted deployments. Listing, showing, pulling, installing, and rendering approved public content use `https://public.observal.io` by default. Publishing, private resources, telemetry, feedback, and account operations still require `observal auth login`.
 
 ## Route the task
 

--- a/observal_cli/tests/test_cmd_agent_versions.py
+++ b/observal_cli/tests/test_cmd_agent_versions.py
@@ -266,7 +266,7 @@ def test_agent_pull_writes_rules_and_mcp(tmp_path: Path) -> None:
     with (
         patch("observal_cli.config.resolve_alias", return_value=agent_id),
         patch("observal_cli.client.get", return_value=agent_detail),
-        patch("observal_cli.client.post", return_value=install_result),
+        patch("observal_cli.client.post_public", return_value=install_result),
     ):
         result = runner.invoke(
             app,
@@ -296,7 +296,7 @@ def test_agent_pull_dry_run(tmp_path: Path) -> None:
     with (
         patch("observal_cli.config.resolve_alias", return_value=agent_id),
         patch("observal_cli.client.get", return_value=agent_detail),
-        patch("observal_cli.client.post", return_value=install_result),
+        patch("observal_cli.client.post_public", return_value=install_result),
     ):
         result = runner.invoke(
             app,
@@ -322,7 +322,7 @@ def test_agent_pull_steering_file(tmp_path: Path) -> None:
     with (
         patch("observal_cli.config.resolve_alias", return_value=agent_id),
         patch("observal_cli.client.get", return_value=agent_detail),
-        patch("observal_cli.client.post", return_value=install_result),
+        patch("observal_cli.client.post_public", return_value=install_result),
     ):
         result = runner.invoke(
             app,
@@ -346,7 +346,7 @@ def test_agent_pull_path_traversal_rejected(tmp_path: Path) -> None:
     with (
         patch("observal_cli.config.resolve_alias", return_value=agent_id),
         patch("observal_cli.client.get", return_value=agent_detail),
-        patch("observal_cli.client.post", return_value=install_result),
+        patch("observal_cli.client.post_public", return_value=install_result),
     ):
         result = runner.invoke(
             app,

--- a/observal_cli/tests/test_public_access.py
+++ b/observal_cli/tests/test_public_access.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from observal_cli import client, config
+from observal_cli.errors import CliError
+
+
+def test_anonymous_read_defaults_to_public_server():
+    assert config.DEFAULTS["server_url"] == ""
+    with patch("observal_cli.config.load", return_value=dict(config.DEFAULTS)):
+        resolved = config.get_or_exit(require_auth=False)
+
+    assert resolved["server_url"] == "https://public.observal.io"
+    assert resolved["access_token"] == ""
+
+
+def test_token_without_server_does_not_fall_back_to_public_instance():
+    persisted = {**config.DEFAULTS, "access_token": "token"}
+    with patch("observal_cli.config.load", return_value=persisted), pytest.raises(CliError):
+        config.get_or_exit(require_auth=False)
+
+
+def test_optional_client_omits_authorization_header():
+    cfg = {"server_url": "https://public.observal.io", "access_token": ""}
+    with (
+        patch("observal_cli.client.config.get_or_exit", return_value=cfg) as get_or_exit,
+        patch("observal_cli.client._enforce_version_once"),
+    ):
+        token = client._OPTIONAL_AUTH.set(True)
+        try:
+            base_url, headers = client._client()
+        finally:
+            client._OPTIONAL_AUTH.reset(token)
+
+    assert base_url == "https://public.observal.io"
+    assert "Authorization" not in headers
+    assert "X-Observal-CLI-Version" in headers
+    get_or_exit.assert_called_once_with(require_auth=False)
+
+
+def test_optional_client_uses_token_when_available():
+    cfg = {"server_url": "https://public.observal.io", "access_token": "token"}
+    with (
+        patch("observal_cli.client.config.get_or_exit", return_value=cfg),
+        patch("observal_cli.client._enforce_version_once"),
+    ):
+        token = client._OPTIONAL_AUTH.set(True)
+        try:
+            _, headers = client._client()
+        finally:
+            client._OPTIONAL_AUTH.reset(token)
+
+    assert headers["Authorization"] == "Bearer token"
+
+
+def test_post_public_uses_optional_auth_client():
+    response = MagicMock(status_code=200, content=b"{}")
+    response.json.return_value = {"ok": True}
+    with (
+        patch("observal_cli.client._client", return_value=("https://public.observal.io", {})) as make_client,
+        patch("observal_cli.client._request_with_retry", return_value=response),
+    ):
+        result = client.post_public("/api/v1/agents/example/install", {"harness": "pi"})
+
+    assert result == {"ok": True}
+    make_client.assert_called_once_with()

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "pnpm": {
     "overrides": {
+      "baseline-browser-mapping": "^2.11.0",
       "brace-expansion": "^5.0.8",
+      "browserslist": "^4.28.7",
       "dompurify": "^3.4.13",
       "postcss": "^8.5.18",
       "nanoid": "^3.3.17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  baseline-browser-mapping: ^2.11.0
   brace-expansion: ^5.0.8
+  browserslist: ^4.28.7
   dompurify: ^3.4.13
   postcss: ^8.5.18
   nanoid: ^3.3.17
@@ -125,8 +127,8 @@ importers:
         specifier: ^6.0.8
         version: 6.0.8(graphql@16.14.2)
       js-yaml:
-        specifier: ^4.3.1
-        version: 4.3.1
+        specifier: ^4.3.2
+        version: 4.3.2
       lucide-react:
         specifier: ^1.7.0
         version: 1.21.0(react@19.2.7)
@@ -1667,8 +1669,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.38:
-    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+  baseline-browser-mapping@2.11.22:
+    resolution: {integrity: sha512-pWc4w51fBFd7mav43/zKRC+RI6f4yfzQoVlfvE8dECePyfkn1bzLp01Fj0QACcyCZyFhiEMyD2qScfKRWgWibA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1676,13 +1678,13 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.9:
+    resolution: {integrity: sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  caniuse-lite@1.0.30001799:
-    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1956,8 +1958,8 @@ packages:
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
-  electron-to-chromium@1.5.376:
-    resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
+  electron-to-chromium@1.5.427:
+    resolution: {integrity: sha512-n14zb3FdsChZ2BNobqNHAJMcP3ifFv4paox2LvCrfVAQcqGiSURgbJl+PfMpHVCNFkStnNc+RRVtPBTVW5PDgw==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -2209,8 +2211,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2502,8 +2504,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-releases@2.0.48:
-    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+  node-releases@2.0.55:
+    resolution: {integrity: sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==}
     engines: {node: '>=18'}
 
   optionator@0.9.4:
@@ -2837,11 +2839,11 @@ packages:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.3:
+    resolution: {integrity: sha512-pJ2sYawQS0R/WI928Gj5GlPhTGzbMelq0+4INtSYNDV9ErKJcX6xjGWkoG/VnB3dpUm00zALaqkrUD77pO5TDQ==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ^4.28.7
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -3001,7 +3003,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -4373,21 +4375,21 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.38: {}
+  baseline-browser-mapping@2.11.22: {}
 
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.2:
+  browserslist@4.28.9:
     dependencies:
-      baseline-browser-mapping: 2.10.38
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.376
-      node-releases: 2.0.48
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.22
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.427
+      node-releases: 2.0.55
+      update-browserslist-db: 1.3.3(browserslist@4.28.9)
 
-  caniuse-lite@1.0.30001799: {}
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -4681,7 +4683,7 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  electron-to-chromium@1.5.376: {}
+  electron-to-chromium@1.5.427: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -4932,7 +4934,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5416,7 +5418,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-releases@2.0.48: {}
+  node-releases@2.0.55: {}
 
   optionator@0.9.4:
     dependencies:
@@ -5789,9 +5791,9 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.3(browserslist@4.28.9):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -46,3 +46,46 @@ test("logout redirects to /login and blocks protected pages", async ({ page }) =
   await page.goto("/dashboard");
   await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
 });
+
+test("public registry can be entered as a guest", async ({ page }) => {
+  await page.route("**/api/v1/config/public", async (route) => {
+    const response = await route.fetch();
+    const config = await response.json();
+    await route.fulfill({ response, json: { ...config, public_registry_enabled: true } });
+  });
+
+  await page.goto("/login");
+  const guestButton = page.getByRole("button", { name: "Sign in as guest" });
+  await expect(guestButton).toBeVisible();
+  await guestButton.click();
+  await expect(page).toHaveURL(/\/$/, { timeout: 10_000 });
+});
+
+test("logout clears account-scoped query data without a reload", async ({ page }) => {
+  let myAgentsRequests = 0;
+  await page.route("**/api/v1/agents/my", async (route) => {
+    myAgentsRequests += 1;
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  const login = async () => {
+    await page.goto("/login");
+    await page.fill("#email", EMAIL);
+    await page.fill("#password", PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: 15_000 });
+  };
+
+  await login();
+  await page.goto("/agents");
+  await expect.poll(() => myAgentsRequests).toBeGreaterThan(0);
+  const requestsBeforeLogout = myAgentsRequests;
+
+  await page.locator("button").filter({ hasText: /demo admin|admin/i }).first().click();
+  await page.locator("text=Sign out").click();
+  await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+
+  await login();
+  await page.goto("/agents");
+  await expect.poll(() => myAgentsRequests).toBeGreaterThan(requestsBeforeLogout);
+});

--- a/tests/test_agent_name_lookup.py
+++ b/tests/test_agent_name_lookup.py
@@ -20,7 +20,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, get_registry_user
 from api.routes.agent import router
 from models.agent import AgentStatus
 from models.user import User, UserRole
@@ -53,6 +53,7 @@ def _app_with(user=None, db=None):
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_registry_user] = lambda: user
     app.dependency_overrides[get_db] = lambda: db
     return app, db, user
 

--- a/tests/test_agent_versions_routes.py
+++ b/tests/test_agent_versions_routes.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 from pydantic import ValidationError
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, get_registry_user
 from api.routes import agent as agent_routes
 from api.routes import agent_versions as routes
 from models.agent import Agent, AgentStatus, AgentVersion
@@ -966,6 +966,7 @@ def _route_app(user, db) -> FastAPI:
     app = FastAPI()
     app.include_router(routes.agent_version_router, prefix="/api/v1/agents")
     app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_registry_user] = lambda: user
     app.dependency_overrides[get_db] = lambda: db
     return app
 

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -217,7 +217,7 @@ def test_request_requires_authenticated_configuration(monkeypatch):
     monkeypatch.setattr(client, "_enforce_version_once", enforce)
 
     with pytest.raises(CliError) as error:
-        client.get("/api/v1/items")
+        client.post("/api/v1/items", {"name": "example"})
 
     assert error.value is failure
     get_config.assert_called_once_with()
@@ -775,7 +775,7 @@ def test_http_wrappers_construct_authenticated_requests(monkeypatch, method):
     monkeypatch.setattr(
         client.config,
         "get_or_exit",
-        lambda: {
+        lambda **_kwargs: {
             "server_url": "https://registry.example.test/",
             "access_token": "fake-access-token",
         },

--- a/tests/test_cmd_auth.py
+++ b/tests/test_cmd_auth.py
@@ -713,6 +713,7 @@ def test_whoami_renders_profile_panel(monkeypatch: pytest.MonkeyPatch) -> None:
     kv_panel = MagicMock(return_value=panel)
     console_print = MagicMock()
     monkeypatch.setattr(auth.client, "get", get)
+    monkeypatch.setattr(auth.config, "get_or_exit", MagicMock(return_value={"access_token": "token"}))
     monkeypatch.setattr(auth, "status_badge", lambda role: f"badge:{role}")
     monkeypatch.setattr(auth, "kv_panel", kv_panel)
     monkeypatch.setattr(auth.console, "print", console_print)
@@ -737,6 +738,7 @@ def test_whoami_json_delegates_to_safe_json_renderer(monkeypatch: pytest.MonkeyP
     output_json = MagicMock()
     spinner = MagicMock()
     monkeypatch.setattr(auth.client, "get", lambda _path: user)
+    monkeypatch.setattr(auth.config, "get_or_exit", MagicMock(return_value={"access_token": "token"}))
     monkeypatch.setattr(auth, "output_json", output_json)
     monkeypatch.setattr(auth, "spinner", spinner)
 

--- a/tests/test_cmd_prompt.py
+++ b/tests/test_cmd_prompt.py
@@ -160,7 +160,10 @@ class TestPromptMy:
 class TestPromptRender:
     def test_render_prompt(self):
         """Test prompt render command with variables."""
-        with _patch_resolve_alias(), _patch_post({"rendered": "Hello Earth!"}) as mock_post:
+        with (
+            _patch_resolve_alias(),
+            patch("observal_cli.client.post_public", return_value={"rendered": "Hello Earth!"}) as mock_post,
+        ):
             result = runner.invoke(cli_app, ["registry", "prompt", "render", "p123", "--var", "target=Earth"])
 
             assert result.exit_code == 0
@@ -273,7 +276,10 @@ def test_prompt_submit_json_is_noninteractive_and_clean():
 
 def test_prompt_render_json_and_variable_validation():
     response = {"rendered": "Review array[0] literally"}
-    with _patch_resolve_alias(), _patch_post(response) as post:
+    with (
+        _patch_resolve_alias(),
+        patch("observal_cli.client.post_public", return_value=response) as post,
+    ):
         rendered = runner.invoke(
             cli_app,
             ["registry", "prompt", "render", "review", "--var", "code=array[0]", "--output", "json"],

--- a/tests/test_cmd_pull_coverage.py
+++ b/tests/test_cmd_pull_coverage.py
@@ -474,7 +474,11 @@ def test_rewrite_kiro_hooks_replaces_observal_entries_and_keeps_user_hooks(monke
         }
     )
     monkeypatch.setattr(spec, "build_kiro_hooks", build)
-    monkeypatch.setattr(cmd_pull.config, "get_or_exit", lambda: {"server_url": "https://registry.example/"})
+    monkeypatch.setattr(
+        cmd_pull.config,
+        "get_or_exit",
+        lambda **_kwargs: {"server_url": "https://registry.example/"},
+    )
     content = {
         "hooks": {
             "stop": [

--- a/tests/test_component_versions_routes.py
+++ b/tests/test_component_versions_routes.py
@@ -15,7 +15,7 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, get_registry_user
 from api.routes import component_versions as versions
 from models.hook import HookListing, HookVersion
 from models.mcp import ListingStatus, McpListing, McpVersion
@@ -1197,6 +1197,7 @@ def _generic_app(component_type="mcp", *, actor=None):
     app.dependency_overrides[get_db] = lambda: db
     if actor is not None:
         app.dependency_overrides[get_current_user] = lambda: actor
+        app.dependency_overrides[get_registry_user] = lambda: actor
     return app, db
 
 
@@ -1410,7 +1411,7 @@ async def test_router_authentication_and_reviewer_role_fail_before_handlers(monk
         unauthenticated = await client.get(f"/api/v1/mcps/{LISTING_ID}/versions")
 
     assert unauthenticated.status_code == 401
-    assert unauthenticated.json() == {"detail": "Missing credentials"}
+    assert unauthenticated.json() == {"detail": "Authentication required"}
     list_call.assert_not_awaited()
 
     user_app, _db_instance = _generic_app(actor=_user(user_id=OWNER_ID))

--- a/tests/test_dashboard_routes.py
+++ b/tests/test_dashboard_routes.py
@@ -15,7 +15,7 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from httpx import ASGITransport, AsyncClient
 
-from api.deps import get_current_user, get_db, optional_current_user
+from api.deps import get_current_user, get_db, get_registry_user
 from api.routes import dashboard
 from models.user import UserRole
 
@@ -307,7 +307,7 @@ async def test_agent_leaderboard_filters_period_and_user_and_serializes_rows(mon
         limit=4,
         user=r"alice%_\team",
         db=db,
-        current_user=None,
+        current_user=_user(),
     )
 
     assert [item.model_dump(mode="json") for item in result] == [
@@ -339,6 +339,24 @@ async def test_agent_leaderboard_filters_period_and_user_and_serializes_rows(mon
 
 
 @pytest.mark.asyncio
+async def test_anonymous_agent_leaderboard_ignores_email_filter():
+    db = _db(_Result())
+
+    result = await dashboard.agent_leaderboard(
+        window="7d",
+        limit=4,
+        user="private@example.test",
+        db=db,
+        current_user=None,
+    )
+
+    assert result == []
+    sql = _sql(db.execute.await_args_list[0].args[0])
+    assert "JOIN users" not in sql
+    assert "private@example.test" not in str(db.execute.await_args_list[0].args[0].compile().params)
+
+
+@pytest.mark.asyncio
 async def test_agent_leaderboard_backfills_zero_download_agents_and_missing_creators():
     extra = SimpleNamespace(
         id=SECOND_AGENT_ID,
@@ -363,7 +381,7 @@ async def test_agent_leaderboard_backfills_zero_download_agents_and_missing_crea
         limit=2,
         user="owner",
         db=db,
-        current_user=None,
+        current_user=_user(),
     )
 
     assert [item.model_dump(mode="json") for item in result] == [
@@ -426,7 +444,7 @@ async def test_component_leaderboard_aggregates_all_types_ratings_and_emails(mon
         limit=5,
         user=r"creator%_\team",
         db=db,
-        current_user=None,
+        current_user=_user(),
     )
 
     assert [(item.component_type, item.download_count, item.total_reviews) for item in result] == [
@@ -467,6 +485,44 @@ async def test_component_leaderboard_aggregates_all_types_ratings_and_emails(mon
     assert "avg(feedback.rating) AS avg_rating" in feedback_sql
     assert "count(feedback.id) AS total_reviews" in feedback_sql
     assert [vars(item) for item in rows] == snapshots
+
+
+@pytest.mark.asyncio
+async def test_anonymous_component_leaderboard_hides_email_and_ignores_filter():
+    component_id = uuid.UUID("00000000-0000-4000-8000-000000000099")
+    row = SimpleNamespace(
+        component_id=component_id,
+        cnt=1,
+        name="Public MCP",
+        namespace="public",
+        slug="public-mcp",
+        description="Public component",
+        submitted_by=USER_ID,
+    )
+    db = _db(
+        _Result([row]),
+        _Result(),
+        _Result(),
+        _Result(),
+        _Result(),
+        _Result(),
+    )
+
+    result = await dashboard.component_leaderboard(
+        window="7d",
+        limit=1,
+        user="private@example.test",
+        db=db,
+        current_user=None,
+    )
+
+    assert len(result) == 1
+    assert result[0].created_by_email == ""
+    assert db.execute.await_count == 6
+    for awaited in db.execute.await_args_list[:5]:
+        statement = awaited.args[0]
+        assert "JOIN users" not in _sql(statement)
+        assert "private@example.test" not in str(statement.compile().params)
 
 
 @pytest.mark.asyncio
@@ -516,7 +572,7 @@ async def test_component_leaderboard_backfills_deduplicates_and_stops_at_limit()
         limit=3,
         user=None,
         db=db,
-        current_user=None,
+        current_user=_user(),
     )
 
     assert [item.id for item in result] == [first_id, second_id, third_id]
@@ -631,22 +687,26 @@ def test_dashboard_route_role_contract_is_explicit():
         "/api/v1/dashboard/unannotated-traces",
     }
 
+    user_paths = {"/api/v1/overview/stats"}
     public_scoped_paths = {
-        "/api/v1/overview/stats",
         "/api/v1/overview/top-mcps",
         "/api/v1/overview/top-agents",
         "/api/v1/overview/leaderboard",
         "/api/v1/overview/component-leaderboard",
     }
 
-    assert admin_paths | public_scoped_paths <= routes.keys()
+    assert admin_paths | user_paths | public_scoped_paths <= routes.keys()
     for path in admin_paths:
         dependencies = [item for item in routes[path].dependant.dependencies if item.name == "current_user"]
         assert len(dependencies) == 1, path
         assert inspect.getclosurevars(dependencies[0].call).nonlocals["min_role"] == UserRole.admin
+    for path in user_paths:
+        dependencies = [item for item in routes[path].dependant.dependencies if item.name == "current_user"]
+        assert len(dependencies) == 1, path
+        assert inspect.getclosurevars(dependencies[0].call).nonlocals["min_role"] == UserRole.user
     for path in public_scoped_paths:
         dependencies = [item for item in routes[path].dependant.dependencies if item.name == "current_user"]
-        assert [item.call for item in dependencies] == [optional_current_user], path
+        assert [item.call for item in dependencies] == [get_registry_user], path
 
     assert all(item.name != "current_user" for item in routes["/api/v1/dashboard/tokens"].dependant.dependencies)
 
@@ -660,6 +720,11 @@ async def _dashboard_app(user=None):
         yield database
 
     app.dependency_overrides[get_db] = database_override
+
+    async def registry_user_override():
+        return user
+
+    app.dependency_overrides[get_registry_user] = registry_user_override
     if user is not None:
 
         async def user_override():

--- a/tests/test_harness_config_e2e.py
+++ b/tests/test_harness_config_e2e.py
@@ -651,7 +651,7 @@ def isolated_lockfile(tmp_path, monkeypatch):
 
 
 def _patch_post(return_value):
-    return patch("observal_cli.client.post", return_value=return_value)
+    return patch("observal_cli.client.post_public", return_value=return_value)
 
 
 _AGENT_DETAIL_NO_ENV = {

--- a/tests/test_listing_detail_access.py
+++ b/tests/test_listing_detail_access.py
@@ -21,7 +21,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from api.deps import get_db, optional_current_user
+from api.deps import get_db, get_registry_user
 from models.mcp import ListingStatus
 from models.user import User, UserRole
 
@@ -56,9 +56,9 @@ def _app_with(router, user=None, membership=None):
     app.include_router(router)
     app.dependency_overrides[get_db] = lambda: db
     if user is not None:
-        app.dependency_overrides[optional_current_user] = lambda: user
+        app.dependency_overrides[get_registry_user] = lambda: user
     else:
-        app.dependency_overrides[optional_current_user] = lambda: None
+        app.dependency_overrides[get_registry_user] = lambda: None
     return app
 
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -103,8 +103,7 @@ def test_current_registry_url_reads_and_normalizes_config(isolated_lockfile):
     assert lockfile.current_registry_url() == "https://registry.example.test/root"
 
     isolated_lockfile.server_url = ""
-    with pytest.raises(ValueError, match="configured server URL"):
-        lockfile.current_registry_url()
+    assert lockfile.current_registry_url() == config.PUBLIC_SERVER_URL
 
 
 def test_read_missing_lockfile_returns_fresh_schema_without_writing(isolated_lockfile):

--- a/tests/test_public_registry_access.py
+++ b/tests/test_public_registry_access.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from api.deps import get_registry_user
+from api.routes import prompt
+from models.mcp import ListingStatus
+from schemas.prompt import PromptRenderRequest
+from services import dynamic_settings
+
+
+def _request(path: str = "/api/v1/agents") -> Request:
+    return Request({"type": "http", "method": "GET", "path": path, "headers": []})
+
+
+@pytest.mark.asyncio
+async def test_public_registry_rejects_guest_when_disabled():
+    with (
+        patch("services.dynamic_settings.get_bool", new=AsyncMock(return_value=False)) as get_bool,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await get_registry_user(_request(), None)
+
+    assert exc_info.value.status_code == 401
+    get_bool.assert_awaited_once_with("deployment.public_registry_enabled")
+
+
+@pytest.mark.asyncio
+async def test_public_registry_accepts_guest_when_enabled():
+    with patch("services.dynamic_settings.get_bool", new=AsyncMock(return_value=True)):
+        assert await get_registry_user(_request(), None) is None
+
+
+@pytest.mark.asyncio
+async def test_public_registry_accepts_authenticated_user_without_setting_lookup():
+    user = SimpleNamespace(id="user-id")
+    redis = MagicMock(get=AsyncMock(return_value=None))
+    with (
+        patch("services.dynamic_settings.get_bool", new=AsyncMock()) as get_bool,
+        patch("api.deps.get_redis", return_value=redis),
+    ):
+        assert await get_registry_user(_request(), user) is user
+
+    get_bool.assert_not_awaited()
+    redis.get.assert_awaited_once_with("must_change_password:user-id")
+
+
+@pytest.mark.asyncio
+async def test_public_registry_preserves_required_password_change_gate():
+    user = SimpleNamespace(id="user-id")
+    redis = MagicMock(get=AsyncMock(return_value="1"))
+    with patch("api.deps.get_redis", return_value=redis), pytest.raises(HTTPException) as exc_info:
+        await get_registry_user(_request(), user)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Password change required"
+
+
+def test_public_registry_setting_is_default_off_and_described():
+    assert dynamic_settings.DEFAULTS["deployment.public_registry_enabled"] == "false"
+    deployment = next(section for section in dynamic_settings.settings_schema() if section["id"] == "deployment")
+    setting = next(item for item in deployment["settings"] if item["key"] == "deployment.public_registry_enabled")
+    assert setting["default"] == "false"
+    assert "signed-out visitors" in setting["subtitle"]
+
+
+@pytest.mark.asyncio
+async def test_public_prompt_render_treats_variable_values_literally():
+    listing = SimpleNamespace(id=uuid.UUID(int=1), template=r"Path: {{ value }}", status=ListingStatus.approved)
+    with patch("api.routes.prompt.resolve_visible_listing", new=AsyncMock(return_value=listing)):
+        result = await prompt.render_prompt(
+            "public/prompt",
+            PromptRenderRequest(variables={"value": r"C:\new\q"}),
+            AsyncMock(),
+            None,
+        )
+
+    assert result.rendered == r"Path: C:\new\q"
+
+
+@pytest.mark.asyncio
+async def test_public_prompt_render_does_not_reprocess_replacement_placeholders():
+    listing = SimpleNamespace(id=uuid.UUID(int=1), template="{{ first }}", status=ListingStatus.approved)
+    with patch("api.routes.prompt.resolve_visible_listing", new=AsyncMock(return_value=listing)):
+        result = await prompt.render_prompt(
+            "public/prompt",
+            PromptRenderRequest(variables={"first": "{{ second }}", "second": "secret"}),
+            AsyncMock(),
+            None,
+        )
+
+    assert result.rendered == "{{ second }}"

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -62,9 +62,15 @@ def isolated_lockfile(tmp_path, monkeypatch):
     monkeypatch.setattr("observal_cli.lockfile._LOCKFILE_LOCK", tmp_path / ".observal/lockfile.lock")
 
 
+@contextmanager
 def _patch_post(return_value: dict):
-    """Patch client.post to return a canned response."""
-    return patch("observal_cli.client.post", return_value=return_value)
+    """Patch authenticated writes and public install requests with one mock."""
+    request = MagicMock(return_value=return_value)
+    with (
+        patch("observal_cli.client.post", request),
+        patch("observal_cli.client.post_public", request),
+    ):
+        yield request
 
 
 # Agent detail with no MCP env vars — used by pull to check for env var prompts

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -13,7 +13,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, get_registry_user
 from models.mcp import ListingStatus
 from models.user import User, UserRole
 
@@ -54,6 +54,7 @@ def _app_with(router, user=None, db=None):
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_registry_user] = lambda: user
     app.dependency_overrides[get_db] = lambda: db
     return app, db, user
 

--- a/tests/test_registry_visibility.py
+++ b/tests/test_registry_visibility.py
@@ -33,7 +33,7 @@ from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from api.deps import get_db, optional_current_user
+from api.deps import get_db, get_registry_user
 
 # api.routes.registry is imported eagerly on purpose: it binds resolve_listing at
 # import time, so a first import that happened inside a patch() block would
@@ -101,7 +101,7 @@ def _app(user):
     app = FastAPI()
     app.include_router(registry_router)
     app.dependency_overrides[get_db] = lambda: AsyncMock()
-    app.dependency_overrides[optional_current_user] = lambda: user
+    app.dependency_overrides[get_registry_user] = lambda: user
     return app
 
 

--- a/tests/test_sec010_agent_listing.py
+++ b/tests/test_sec010_agent_listing.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for agent listing endpoint access.
 
-Verifies that anonymous callers are rejected and authenticated callers
-can list agents.
+Anonymous callers are rejected by default. The public registry dependency can
+admit guests while authenticated callers continue to receive their user scope.
 """
 
 import uuid
@@ -66,9 +66,31 @@ async def test_anonymous_rejected_from_list_agents():
 
 
 @pytest.mark.asyncio
+async def test_public_registry_guest_can_list_agents():
+    """The public registry dependency admits a guest without widening data scope."""
+    from api.deps import get_db, get_registry_user
+    from main import app
+
+    mock = _mock_db()
+
+    async def _fake_db():
+        yield mock
+
+    app.dependency_overrides[get_db] = _fake_db
+    app.dependency_overrides[get_registry_user] = lambda: None
+
+    try:
+        async with _make_client() as client:
+            response = await client.get("/api/v1/agents")
+        assert response.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
 async def test_authenticated_user_can_list_agents():
     """Authenticated users get a 200 from the agent list endpoint."""
-    from api.deps import get_current_user, get_db
+    from api.deps import get_db, get_registry_user
     from main import app
 
     user = _user()
@@ -78,7 +100,7 @@ async def test_authenticated_user_can_list_agents():
         yield mock
 
     app.dependency_overrides[get_db] = _fake_db
-    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_registry_user] = lambda: user
 
     try:
         async with _make_client() as client:

--- a/tests/test_sec027_registry_sc.py
+++ b/tests/test_sec027_registry_sc.py
@@ -12,7 +12,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from api.deps import get_current_user, get_db
+from api.deps import get_current_user, get_db, get_registry_user
 from api.routes.agent import router
 from models.agent import AgentStatus
 from models.user import User, UserRole
@@ -45,6 +45,7 @@ def _app_with(user=None, db=None):
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_registry_user] = lambda: user
     app.dependency_overrides[get_db] = lambda: db
     return app, db, user
 

--- a/tests/test_skill_routes.py
+++ b/tests/test_skill_routes.py
@@ -682,6 +682,54 @@ class TestListAndDetail:
 
 class TestInstallSkill:
     @pytest.mark.asyncio
+    async def test_anonymous_approved_install_does_not_change_download_metrics(self, monkeypatch):
+        db = _db()
+        listing = _listing()
+        commit = AsyncMock()
+        monkeypatch.setattr(skill, "resolve_visible_listing", AsyncMock(return_value=listing))
+        monkeypatch.setattr(skill, "commit_or_name_conflict", commit)
+        monkeypatch.setattr("api.routes.config.derive_endpoints", AsyncMock(return_value={"api": "https://api.test"}))
+        monkeypatch.setattr(
+            "services.skill_config_generator.generate_skill_config",
+            Mock(return_value={"skill": {"name": "review"}}),
+        )
+
+        response = await skill.install_skill(
+            "alice/review-skill",
+            SkillInstallRequest(harness="pi"),
+            MagicMock(),
+            db,
+            None,
+        )
+
+        assert response.config_snippet == {"skill": {"name": "review"}}
+        assert listing.latest_version.download_count == 7
+        db.add.assert_not_called()
+        commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_anonymous_archived_install_is_hidden(self, monkeypatch):
+        db = _db()
+        listing = _listing(status=ListingStatus.archived)
+        monkeypatch.setattr(skill, "resolve_visible_listing", AsyncMock(side_effect=[None, listing]))
+        commit = AsyncMock()
+        monkeypatch.setattr(skill, "commit_or_name_conflict", commit)
+
+        with pytest.raises(HTTPException) as exc:
+            await skill.install_skill(
+                "alice/review-skill",
+                SkillInstallRequest(harness="pi"),
+                MagicMock(),
+                db,
+                None,
+            )
+
+        _http_error(exc, 404, "Listing not found or not approved")
+        assert listing.latest_version.download_count == 7
+        db.add.assert_not_called()
+        commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_archived_version_install_tracks_usage_then_generates_exact_config(self, monkeypatch):
         db = _db()
         listing = _listing(status=ListingStatus.archived)

--- a/web/package.json
+++ b/web/package.json
@@ -50,7 +50,7 @@
     "cmdk": "^1.1.1",
     "codemirror": "^6.0.2",
     "graphql-ws": "^6.0.8",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^4.3.2",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.16.1",
     "react": "19.2.7",

--- a/web/src/components/layouts/auth-guard.tsx
+++ b/web/src/components/layouts/auth-guard.tsx
@@ -17,7 +17,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
  * Resolves role for authenticated users so sidebar can show/hide admin items.
  */
 export function OptionalAuthGuard({ children }: { children: React.ReactNode }) {
-  useOptionalAuth();
-  // Render children immediately to prevent hydration mismatch
+  const { ready } = useOptionalAuth();
+  if (!ready) return <div className="flex h-screen w-full items-center justify-center" />;
   return <>{children}</>;
 }

--- a/web/src/components/nav/registry-sidebar.tsx
+++ b/web/src/components/nav/registry-sidebar.tsx
@@ -42,6 +42,7 @@ import {
 	KeyRound,
 	BookOpen,
 	Inbox,
+	LogIn,
 } from "lucide-react";
 import { useSyncExternalStore } from "react";
 import {
@@ -352,13 +353,26 @@ export function RegistrySidebar() {
 			</SidebarContent>
 			<SidebarFooter>
 				<ServerVersionBadge />
-				<NavUser
-					user={{
-						name: userName || "User",
-						email: userEmail || "",
-						username: userUsername || undefined,
-					}}
-				/>
+				{isAuthenticated ? (
+					<NavUser
+						user={{
+							name: userName || "User",
+							email: userEmail || "",
+							username: userUsername || undefined,
+						}}
+					/>
+				) : (
+					<SidebarMenu>
+						<SidebarMenuItem>
+							<SidebarMenuButton asChild size="lg">
+								<Link to="/login">
+									<LogIn className="h-4 w-4" />
+									<span>Sign in to contribute</span>
+								</Link>
+							</SidebarMenuButton>
+						</SidebarMenuItem>
+					</SidebarMenu>
+				)}
 			</SidebarFooter>
 			<SidebarRail />
 		</Sidebar>

--- a/web/src/hooks/use-admin-api.ts
+++ b/web/src/hooks/use-admin-api.ts
@@ -28,10 +28,13 @@ import { hasMinRole } from "@/hooks/use-role-guard";
 
 // ── Auth ────────────────────────────────────────────────────────────
 
-export function useWhoami() {
+export function useWhoami(
+  enabled = typeof window !== "undefined" && !!sessionStorage.getItem("observal_access_token"),
+) {
   return useQuery({
     queryKey: ["auth", "whoami"],
     queryFn: auth.whoami,
+    enabled,
     retry: false,
   });
 }

--- a/web/src/hooks/use-agents-api.ts
+++ b/web/src/hooks/use-agents-api.ts
@@ -26,10 +26,11 @@ import type { LeaderboardWindow } from "@/lib/types";
 
 // ── Agent-specific ──────────────────────────────────────────────────
 
-export function useMyAgents() {
+export function useMyAgents(enabled = true) {
   return useQuery({
     queryKey: ["registry", "agents", "my"],
     queryFn: () => registry.my(),
+    enabled,
   });
 }
 

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -5,7 +5,7 @@
 // SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { useRouter, useLocation } from "@tanstack/react-router";
 import { auth, setUserRole, getUserRole, clearSession, refreshAccessTokenWithReason } from "@/lib/api";
 import { currentPathAsNext } from "@/lib/safe-next";
@@ -34,6 +34,78 @@ function getServerSnapshot() {
   return "ssr";
 }
 
+function retryUntilSettled(
+  attemptRequest: () => Promise<"ok" | "rejected" | "network_error">,
+  { onSuccess, onRejected, onNetworkError }: {
+    onSuccess?: () => void;
+    onRejected?: () => void;
+    onNetworkError?: () => void;
+  } = {},
+) {
+  let cancelled = false;
+  let inFlight = false;
+  let retryTimer: number | undefined;
+
+  const attempt = async () => {
+    if (cancelled || inFlight) return;
+    inFlight = true;
+    const result = await attemptRequest();
+    inFlight = false;
+    if (cancelled) return;
+
+    if (result === "ok") {
+      onSuccess?.();
+      window.dispatchEvent(new Event("storage"));
+    } else if (result === "rejected") {
+      clearSession();
+      onRejected?.();
+    } else {
+      onNetworkError?.();
+      retryTimer = window.setTimeout(attempt, 5_000);
+    }
+  };
+
+  const retryNow = () => {
+    if (retryTimer) window.clearTimeout(retryTimer);
+    void attempt();
+  };
+
+  window.addEventListener("online", retryNow);
+  void attempt();
+  return () => {
+    cancelled = true;
+    if (retryTimer) window.clearTimeout(retryTimer);
+    window.removeEventListener("online", retryNow);
+  };
+}
+
+function retryRefreshUntilSettled(onRejected?: () => void) {
+  return retryUntilSettled(refreshAccessTokenWithReason, { onRejected });
+}
+
+function retryWhoamiUntilSettled({
+  onSuccess,
+  onRejected,
+  onNetworkError,
+}: {
+  onSuccess?: () => void;
+  onRejected?: () => void;
+  onNetworkError?: () => void;
+} = {}) {
+  return retryUntilSettled(
+    async () => {
+      try {
+        const user = await auth.whoami();
+        setUserRole(user.role);
+        return "ok";
+      } catch (err) {
+        return isNetworkError(err) ? "network_error" : "rejected";
+      }
+    },
+    { onSuccess, onRejected, onNetworkError },
+  );
+}
+
 export function useAuthGuard() {
   const router = useRouter();
   const { pathname } = useLocation();
@@ -49,17 +121,9 @@ export function useAuthGuard() {
 
     // New tab: no access token but refresh token exists. Try silent refresh.
     if (isRefreshing) {
-      refreshAccessTokenWithReason().then((result) => {
-        if (result === "ok") {
-          window.dispatchEvent(new Event("storage"));
-        } else if (result === "rejected") {
-          clearSession();
-          window.dispatchEvent(new Event("storage"));
-          router.navigate({ to: "/login", replace: true, search: { next: currentPathAsNext() } });
-        }
-        // "network_error": do nothing, leave session intact
+      return retryRefreshUntilSettled(() => {
+        router.navigate({ to: "/login", replace: true, search: { next: currentPathAsNext() } });
       });
-      return;
     }
 
     if (!hasToken && pathname !== "/login") {
@@ -69,14 +133,10 @@ export function useAuthGuard() {
     if (!hasToken) return;
 
     if (snapshot === "pending") {
-      auth.whoami().then((user) => {
-        setUserRole(user.role);
-        window.dispatchEvent(new Event("storage"));
-      }).catch((err) => {
-        if (isNetworkError(err)) return;
-        clearSession();
-        window.dispatchEvent(new Event("storage"));
-        router.navigate({ to: "/login", replace: true, search: { next: currentPathAsNext() } });
+      return retryWhoamiUntilSettled({
+        onRejected: () => {
+          router.navigate({ to: "/login", replace: true, search: { next: currentPathAsNext() } });
+        },
       });
     }
   }, [isSSR, hasToken, isRefreshing, snapshot, pathname, router]);
@@ -91,23 +151,29 @@ export function useAuthGuard() {
  */
 export function useOptionalAuth() {
   const snapshot = useSyncExternalStore(subscribe, getAuthSnapshot, getServerSnapshot);
-  const hasToken = snapshot !== "";
-  const ready = !hasToken || snapshot !== "pending";
-  const role = (hasToken && snapshot !== "pending") ? snapshot : null;
-  const isAuthenticated = hasToken && snapshot !== "pending";
+  const [networkFallback, setNetworkFallback] = useState(false);
+  const isRefreshing = snapshot === "refreshing";
+  const hasToken = snapshot !== "" && snapshot !== "ssr" && !isRefreshing;
+  const useAnonymousFallback = networkFallback && snapshot === "pending";
+  const ready = useAnonymousFallback || (snapshot !== "pending" && !isRefreshing);
+  const role = !useAnonymousFallback && hasToken && snapshot !== "pending" ? snapshot : null;
+  const isAuthenticated = !useAnonymousFallback && hasToken && snapshot !== "pending";
 
   useEffect(() => {
+    if (isRefreshing) {
+      return retryRefreshUntilSettled();
+    }
+
     if (hasToken && snapshot === "pending") {
-      auth.whoami().then((user) => {
-        setUserRole(user.role);
-        window.dispatchEvent(new Event("storage"));
-      }).catch((err) => {
-        if (isNetworkError(err)) return;
-        clearSession();
-        window.dispatchEvent(new Event("storage"));
+      return retryWhoamiUntilSettled({
+        onSuccess: () => setNetworkFallback(false),
+        onNetworkError: () => {
+          setNetworkFallback(true);
+          window.dispatchEvent(new Event("observal:session-cleared"));
+        },
       });
     }
-  }, [hasToken, snapshot]);
+  }, [hasToken, isRefreshing, snapshot]);
 
   return { ready, role, isAuthenticated };
 }

--- a/web/src/hooks/use-deployment-config.ts
+++ b/web/src/hooks/use-deployment-config.ts
@@ -23,6 +23,7 @@ export function useDeploymentConfig() {
 		googleSsoEnabled: data?.google_sso_enabled ?? false,
 		githubSsoEnabled: data?.github_sso_enabled ?? false,
 		ssoOnly: data?.sso_only ?? false,
+		publicRegistryEnabled: data?.public_registry_enabled ?? false,
 		selfRegistrationEnabled: data?.self_registration_enabled ?? false,
 		samlEnabled: data?.saml_enabled ?? false,
 		enabledFeatures: data?.enabled_features ?? [],

--- a/web/src/hooks/use-insights-api.ts
+++ b/web/src/hooks/use-insights-api.ts
@@ -66,10 +66,10 @@ export function useSubmitFeedback() {
   });
 }
 
-export function useMyFeedback(type: string | undefined, id: string | undefined) {
+export function useMyFeedback(type: string | undefined, id: string | undefined, enabled = true) {
   return useQuery({
     queryKey: ["feedback", "mine", type, id],
-    enabled: !!type && !!id,
+    enabled: !!type && !!id && enabled,
     queryFn: () => feedback.mine(type!, id!),
     retry: (_count, err: unknown) => {
       const status = (err as { status?: number })?.status;
@@ -109,28 +109,29 @@ export function useDeleteFeedback() {
 
 // ── Insights ───────────────────────────────────────────────────────
 
-export function useInsightsStatus() {
+export function useInsightsStatus(enabled = true) {
   return useQuery({
     queryKey: ["insights", "status"],
     queryFn: () => insights.status(),
+    enabled,
     staleTime: 0,
   });
 }
 
-export function useInsightSessionCount(agentId: string | undefined, agentVersion?: string | null) {
+export function useInsightSessionCount(agentId: string | undefined, agentVersion?: string | null, enabled = true) {
   return useQuery({
     queryKey: ["insights", "session-count", agentId, agentVersion],
     queryFn: () => insights.sessionCount(agentId!, agentVersion ?? undefined),
-    enabled: !!agentId,
+    enabled: !!agentId && enabled,
     refetchInterval: 30_000,
   });
 }
 
-export function useInsightReports(agentId: string | undefined) {
+export function useInsightReports(agentId: string | undefined, enabled = true) {
   return useQuery({
     queryKey: ["insights", "reports", agentId],
     queryFn: () => insights.listReports(agentId!),
-    enabled: !!agentId,
+    enabled: !!agentId && enabled,
     refetchInterval: (query) => {
       const reports = query.state.data;
       if (Array.isArray(reports) && reports.some((r: { status: string }) => r.status === "pending" || r.status === "running")) {

--- a/web/src/hooks/use-registry-api.ts
+++ b/web/src/hooks/use-registry-api.ts
@@ -23,10 +23,11 @@ import {
 
 // ── Component Draft/Submit (generic) ──────────────────────────────
 
-export function useMyComponents(type: RegistryType) {
+export function useMyComponents(type: RegistryType, enabled = true) {
   return useQuery({
     queryKey: ["registry", type, "my"],
     queryFn: () => registry.my(type),
+    enabled,
   });
 }
 

--- a/web/src/hooks/use-sessions-api.ts
+++ b/web/src/hooks/use-sessions-api.ts
@@ -30,6 +30,7 @@ export function useSessions2(options?: {
   limit?: number;
   offset?: number;
   mine?: boolean;
+  enabled?: boolean;
 }) {
   return useQuery({
     queryKey: ['sessions', 'list', options?.platform, options?.user, options?.days, options?.limit, options?.offset, options?.mine],
@@ -42,6 +43,7 @@ export function useSessions2(options?: {
         offset: options?.offset,
         mine: options?.mine,
       }),
+    enabled: options?.enabled ?? true,
     refetchInterval: options?.refetchInterval,
     refetchOnMount: "always",
     staleTime: 0,

--- a/web/src/hooks/use-teams-api.ts
+++ b/web/src/hooks/use-teams-api.ts
@@ -11,10 +11,11 @@ const JOIN_REQUESTS_KEY = (teamId: string | undefined) => ["teams", teamId, "joi
 const TEAMS_STALE_MS = 5 * 60 * 1000;
 const TEAM_REFRESH_MS = 10 * 1000;
 
-export function useTeams() {
+export function useTeams(enabled = true) {
 	return useQuery({
 		queryKey: ["teams"],
 		queryFn: teams.list,
+		enabled,
 		staleTime: TEAMS_STALE_MS,
 		refetchOnWindowFocus: "always",
 	});

--- a/web/src/hooks/use-traces-api.ts
+++ b/web/src/hooks/use-traces-api.ts
@@ -56,10 +56,10 @@ export function useRegistryResolve(type: RegistryType, identifier: string | unde
   });
 }
 
-export function useRegistryMetrics(type: RegistryType, id: string | undefined) {
+export function useRegistryMetrics(type: RegistryType, id: string | undefined, enabled = true) {
   return useQuery({
     queryKey: ["registry", type, id, "metrics"],
-    enabled: !!id,
+    enabled: !!id && enabled,
     queryFn: () => registry.metrics(type, id!),
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -123,6 +123,7 @@ function getRefreshToken(): string | null {
 export function setTokens(accessToken: string, refreshToken: string) {
 	sessionStorage.setItem(STORAGE_KEY_ACCESS_TOKEN, accessToken);
 	localStorage.setItem(STORAGE_KEY_REFRESH_TOKEN, refreshToken);
+	window.dispatchEvent(new Event("storage"));
 }
 
 export function clearSession() {
@@ -134,6 +135,8 @@ export function clearSession() {
 	localStorage.removeItem(STORAGE_KEY_USER_EMAIL);
 	localStorage.removeItem(STORAGE_KEY_USER_USERNAME);
 	localStorage.removeItem(STORAGE_KEY_USER_AVATAR);
+	window.dispatchEvent(new Event("observal:session-cleared"));
+	window.dispatchEvent(new Event("storage"));
 }
 
 export function setUserRole(role: string) {
@@ -979,6 +982,7 @@ export type PublicConfig = {
 	google_sso_enabled: boolean;
 	github_sso_enabled: boolean;
 	sso_only: boolean;
+	public_registry_enabled: boolean;
 	self_registration_enabled: boolean;
 	saml_enabled: boolean;
 	exec_dashboard_available: boolean;

--- a/web/src/lib/public-registry.ts
+++ b/web/src/lib/public-registry.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+export function isPublicRegistryPath(pathname: string): boolean {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0) return true;
+  if (["leaderboard", "wiki"].includes(segments[0])) return segments.length === 1;
+  if (segments[0] === "components") {
+    return segments.length === 1 || segments.length === 2 || segments.length === 4;
+  }
+  if (segments[0] === "agents") {
+    return (
+      segments.length === 1 ||
+      (segments.length === 2 && segments[1] !== "builder") ||
+      (segments.length === 3 && segments[2] !== "insights")
+    );
+  }
+  return false;
+}

--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -215,6 +215,7 @@ export default function SettingsPage() {
 	const {
 		ssoEnabled,
 		samlEnabled,
+		publicRegistryEnabled,
 		brandingLogo,
 		brandingAppName,
 		brandingWordmark,
@@ -228,6 +229,7 @@ export default function SettingsPage() {
 	const [tracePrivacy, setTracePrivacy] = useState(false);
 	const [tracePrivacyLoading, setTracePrivacyLoading] = useState(true);
 	const [tracePrivacyToggling, setTracePrivacyToggling] = useState(false);
+	const [publicRegistryToggling, setPublicRegistryToggling] = useState(false);
 	const [registeredAgentsOnly, setRegisteredAgentsOnly] = useState(false);
 	const [registeredAgentsOnlyLoading, setRegisteredAgentsOnlyLoading] =
 		useState(() => hasMinRole(getUserRole(), "super_admin"));
@@ -352,6 +354,24 @@ export default function SettingsPage() {
 			setTracePrivacyToggling(false);
 		}
 	}, []);
+
+	const handlePublicRegistryToggle = useCallback(async (checked: boolean) => {
+		setPublicRegistryToggling(true);
+		try {
+			await admin.updateSetting("deployment.public_registry_enabled", {
+				value: checked ? "true" : "false",
+			});
+			await queryClient.invalidateQueries({ queryKey: ["config", "public"] });
+			await refetch();
+			toast.success(`Public registry access ${checked ? "enabled" : "disabled"}`);
+		} catch (e) {
+			toast.error(
+				e instanceof Error ? e.message : "Failed to update public registry access",
+			);
+		} finally {
+			setPublicRegistryToggling(false);
+		}
+	}, [queryClient, refetch]);
 
 	const handleRegisteredAgentsOnlyToggle = useCallback(
 		async (checked: boolean) => {
@@ -987,6 +1007,30 @@ export default function SettingsPage() {
 					</div>
 				</section>
 
+				{/* Public registry access */}
+				<section className="animate-in">
+					<h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-1.5">
+						<Eye className="h-3.5 w-3.5" />
+						Public Registry
+					</h3>
+					<div className="rounded-md border border-border bg-card px-4 py-3">
+						<div className="flex items-center justify-between gap-4">
+							<div className="flex-1">
+								<p className="text-sm font-medium">Allow public browsing and installs</p>
+								<p className="text-xs text-muted-foreground mt-0.5">
+									Signed-out visitors can browse and install approved public agents and components. Publishing, private content, telemetry, and administration still require sign-in.
+								</p>
+							</div>
+							<Switch
+								checked={publicRegistryEnabled}
+								onCheckedChange={handlePublicRegistryToggle}
+								disabled={publicRegistryToggling}
+								aria-label="Allow public registry browsing and installs"
+							/>
+						</div>
+					</div>
+				</section>
+
 				{/* Trace Privacy */}
 				<section className="animate-in">
 					<h3 className={`text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-1.5 ${sectionHelpHeadingClass("Trace Privacy")}`} onClick={(event) => { if ((event.ctrlKey || event.metaKey) && openHelp(undefined, "Trace Privacy")) event.preventDefault(); }}>
@@ -1292,7 +1336,9 @@ export default function SettingsPage() {
 						{/* Add new setting form */}
 						{/* Unified sections, each setting stays in its section */}
 						{settingSections.filter((s) => !s.danger).map((section) => {
-								const visibleSettings = section.settings;
+								const visibleSettings = section.settings.filter(
+									(setting) => setting.key !== "deployment.public_registry_enabled",
+								);
 								if (visibleSettings.length === 0) return null;
 
 								if (section.title === "Agent Insights") {
@@ -1406,7 +1452,9 @@ export default function SettingsPage() {
 										<p className="text-xs text-foreground/60 mb-4">These settings can affect authentication, security, and data integrity.</p>
 										<div className="space-y-4">
 											{settingSections.filter((s) => s.danger).map((section) => {
-												const visibleDangerSettings = section.settings;
+												const visibleDangerSettings = section.settings.filter(
+													(setting) => setting.key !== "deployment.public_registry_enabled",
+												);
 												if (visibleDangerSettings.length === 0) return null;
 												return (
 												<details key={section.title} className="group rounded-md border-l-4 border-amber-500/60 border-2 border-border/70 bg-card">

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -11,6 +11,7 @@ import { Link, useRouter, useSearch } from "@tanstack/react-router";
 import { Eye, EyeOff, ArrowRight, Loader2, AlertCircle, RefreshCw, CheckCircle2, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { auth, config as configApi, setTokens, clearSession, setUserRole, getUserRole, setUserName, setUserEmail, setUserUsername, setUserAvatar } from "@/lib/api";
+import { isPublicRegistryPath } from "@/lib/public-registry";
 import { isSafeNext, safeNext } from "@/lib/safe-next";
 import type { SsoHealthResult, E2eStatusResult, HealthCheck } from "@/lib/api";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
@@ -29,6 +30,7 @@ function LoginContent() {
     googleSsoEnabled,
     githubSsoEnabled,
     ssoOnly,
+    publicRegistryEnabled,
     selfRegistrationEnabled,
     samlEnabled,
     brandingAppName,
@@ -261,6 +263,13 @@ function LoginContent() {
     window.location.href = ssoStartUrl("/api/v1/sso/saml/login");
   }
 
+  function handleGuestLogin() {
+    clearSession();
+    const requestedPath = safeNext(searchParams.next);
+    const pathname = requestedPath.split(/[?#]/, 1)[0];
+    window.location.replace(isPublicRegistryPath(pathname) ? requestedPath : "/");
+  }
+
   useEffect(() => {
     if (searchParams.sso !== "1" || directSsoStarted.current) return;
     directSsoStarted.current = true;
@@ -389,7 +398,7 @@ function LoginContent() {
               </h1>
             )}
             <p className="text-sm text-muted-foreground">
-              Sign in to your account
+              {publicRegistryEnabled ? "Sign in or browse the public registry" : "Sign in to your account"}
             </p>
           </div>
 
@@ -624,6 +633,32 @@ function LoginContent() {
                       )}
                     </Button>
                   </div>
+                )}
+
+                {publicRegistryEnabled && (
+                  <>
+                    <div className="relative py-2">
+                      <div className="absolute inset-0 flex items-center">
+                        <span className="w-full border-t" />
+                      </div>
+                      <div className="relative flex justify-center text-xs uppercase">
+                        <span className="bg-card px-2 text-muted-foreground">Public access</span>
+                      </div>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-full"
+                      onClick={handleGuestLogin}
+                      disabled={loading || ssoLoading}
+                    >
+                      Sign in as guest
+                      <ArrowRight className="ml-1 h-4 w-4" />
+                    </Button>
+                    <p className="text-center text-xs leading-5 text-muted-foreground">
+                      Browse and install approved public registry content without an account.
+                    </p>
+                  </>
                 )}
               </div>
 

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -24,7 +24,7 @@ import {
   Sparkles,
   AlertTriangle,
 } from "lucide-react";
-import { useState, useEffect, useCallback, useMemo, useSyncExternalStore } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 
 import {
@@ -46,7 +46,7 @@ import {
   useDeleteAgent,
   useUnarchiveAgent,
 } from "@/hooks/use-api";
-import { getUserRole } from "@/lib/api";
+import { useOptionalAuth } from "@/hooks/use-auth";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import type {
   AgentComponentReference,
@@ -513,10 +513,10 @@ function InsightStatusBadge({ status }: { status: InsightReportListItem["status"
   }
 }
 
-function InsightsTab({ agentId, agentVersion }: { agentId: string; agentVersion?: string | null }) {
-  const { data: reports, isLoading: reportsLoading } = useInsightReports(agentId);
-  const { data: sessionCountData, isLoading: countLoading } = useInsightSessionCount(agentId, agentVersion);
-  const { data: insightsStatus } = useInsightsStatus();
+function InsightsTab({ agentId, agentVersion, enabled }: { agentId: string; agentVersion?: string | null; enabled: boolean }) {
+  const { data: reports, isLoading: reportsLoading } = useInsightReports(agentId, enabled);
+  const { data: sessionCountData, isLoading: countLoading } = useInsightSessionCount(agentId, agentVersion, enabled);
+  const { data: insightsStatus } = useInsightsStatus(enabled);
   const generateInsight = useGenerateInsight();
 
   const availableSessions = sessionCountData?.session_count ?? 0;
@@ -631,6 +631,7 @@ export default function AgentDetailPage({ agentId }: { agentId?: string } = {}) 
   const params = useParams({ strict: false }) as { agentId?: string };
   const id = agentId ?? params.agentId ?? "";
   const navigate = useNavigate();
+  const { isAuthenticated, role } = useOptionalAuth();
   const {
     data: agent,
     isLoading,
@@ -645,10 +646,10 @@ export default function AgentDetailPage({ agentId }: { agentId?: string } = {}) 
   );
   const { data: feedbackSummary, refetch: refetchSummary } =
     useFeedbackSummary(id);
-  const { data: myReview } = useMyFeedback("agent", id);
+  const { data: myReview } = useMyFeedback("agent", id, isAuthenticated);
 
-  const { data: whoami } = useWhoami();
-  const { data: teams = [] } = useTeams();
+  const { data: whoami } = useWhoami(isAuthenticated);
+  const { data: teams = [] } = useTeams(isAuthenticated);
   const updateVisibility = useUpdateRegistryVisibility();
   const { data: versionsData } = useAgentVersions(id);
   const versions = versionsData?.items ?? [];
@@ -662,6 +663,10 @@ export default function AgentDetailPage({ agentId }: { agentId?: string } = {}) 
   // Co-authors
   const [coAuthors, setCoAuthors] = useState<CoAuthor[]>([]);
   useEffect(() => {
+    if (!isAuthenticated) {
+      setCoAuthors([]);
+      return;
+    }
     const token = sessionStorage.getItem("observal_access_token");
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
@@ -669,22 +674,9 @@ export default function AgentDetailPage({ agentId }: { agentId?: string } = {}) 
       .then((r) => (r.ok ? r.json() : []))
       .then((data) => setCoAuthors(data))
       .catch(() => {});
-  }, [id]);
+  }, [id, isAuthenticated]);
 
-  const storeSub = useCallback((cb: () => void) => {
-    window.addEventListener("storage", cb);
-    return () => window.removeEventListener("storage", cb);
-  }, []);
-  const isAuthenticated = useSyncExternalStore(
-    storeSub,
-    () => !!sessionStorage.getItem("observal_access_token"),
-    () => false,
-  );
-  const isAdmin = useSyncExternalStore(
-    storeSub,
-    () => hasMinRole(getUserRole(), "admin"),
-    () => false,
-  );
+  const isAdmin = isAuthenticated && hasMinRole(role, "admin");
 
   const a = agent as unknown as AgentDetail | undefined;
   const effectiveVersion = selectedVersion ?? latestApprovedVersion ?? a?.version;
@@ -715,7 +707,7 @@ export default function AgentDetailPage({ agentId }: { agentId?: string } = {}) 
   // and a personal one needs its creator.
   const canChangeVisibility = Boolean(
     a &&
-      (hasMinRole(getUserRole(), "admin") ||
+      (hasMinRole(role, "admin") ||
         (a.team_id ? teamRole === "owner" || teamRole === "reviewer" : isOwner)),
   );
   const currentVisibility = a?.visibility ?? (a?.is_private ? "team" : "public");
@@ -1097,7 +1089,7 @@ export default function AgentDetailPage({ agentId }: { agentId?: string } = {}) 
                 )}
                 {canEdit && (
                   <TabsContent value="insights" className="mt-6">
-                    <InsightsTab agentId={id} agentVersion={effectiveVersion} />
+                    <InsightsTab agentId={id} agentVersion={effectiveVersion} enabled={canEdit} />
                   </TabsContent>
                 )}
 

--- a/web/src/pages/registry/agents/index.tsx
+++ b/web/src/pages/registry/agents/index.tsx
@@ -35,6 +35,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRegistryList, useMyAgents, useArchivedAgents, useDeletedAgents, useWhoami, useArchiveAgent, useUnarchiveAgent, useDeleteAgent, useRestoreDeletedAgent, useSubmitDraft, useTeams } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
+import { useOptionalAuth } from "@/hooks/use-auth";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import {
   Table,
@@ -426,7 +427,8 @@ export default function AgentListPage() {
 function AgentListContent() {
   const { search: searchParam, namespace, team, category } = useSearch({ from: "/_authed/agents/" });
   const router = useRouter();
-  const { data: teams = [] } = useTeams();
+  const { isAuthenticated } = useOptionalAuth();
+  const { data: teams = [] } = useTeams(isAuthenticated);
   const selectedTeam = teams.find((item) => item.handle === team);
   const initialSearch = searchParam ?? "";
   const [search, setSearch] = useState(initialSearch);
@@ -462,10 +464,14 @@ function AgentListContent() {
     ...(category ? { category } : {}),
   });
 
-  const { data: myAgents } = useMyAgents();
-  const isAdmin = useSyncExternalStore(roleSub, () => hasMinRole(getUserRole(), "admin"), () => false);
+  const { data: myAgents } = useMyAgents(isAuthenticated);
+  const isAdmin = useSyncExternalStore(
+    roleSub,
+    () => isAuthenticated && hasMinRole(getUserRole(), "admin"),
+    () => false,
+  );
   const { data: allArchivedAgents } = useArchivedAgents(isAdmin);
-  const { data: deletedAgents = [] } = useDeletedAgents();
+  const { data: deletedAgents = [] } = useDeletedAgents(isAuthenticated);
   const submitDraft = useSubmitDraft();
   const [draftsExpanded, setDraftsExpanded] = useState(true);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
@@ -473,25 +479,30 @@ function AgentListContent() {
   const [deletingDraftId, setDeletingDraftId] = useState<string | null>(null);
   const qc = useQueryClient();
 
+  const scopedMyAgents = useMemo(
+    () => (isAuthenticated ? (myAgents ?? []) : []),
+    [isAuthenticated, myAgents],
+  );
+
   const drafts = useMemo(() => {
-    return (myAgents ?? []).filter((a) => a.status === "draft" || a.status === "rejected" || a.status === "pending");
-  }, [myAgents]);
+    return scopedMyAgents.filter((a) => a.status === "draft" || a.status === "rejected" || a.status === "pending");
+  }, [scopedMyAgents]);
 
   const archivedAgents = useMemo(() => {
     if (isAdmin && allArchivedAgents) {
       return allArchivedAgents;
     }
-    return (myAgents ?? []).filter((a) => a.status === "archived");
-  }, [isAdmin, allArchivedAgents, myAgents]);
+    return scopedMyAgents.filter((a) => a.status === "archived");
+  }, [isAdmin, allArchivedAgents, scopedMyAgents]);
 
   const { filtered, pendingCount } = useMemo(() => {
     const active = agents ?? [];
     const activeIds = new Set(active.map((a) => a.id));
-    const pending = (myAgents ?? []).filter(
+    const pending = scopedMyAgents.filter(
       (a) => a.status !== "approved" && a.status !== "draft" && a.status !== "rejected" && a.status !== "archived" && !activeIds.has(a.id),
     );
     return { filtered: [...pending, ...active], pendingCount: pending.length };
-  }, [agents, myAgents]);
+  }, [agents, scopedMyAgents]);
 
   const table = useReactTable({
     data: filtered,
@@ -570,33 +581,37 @@ function AgentListContent() {
                 className="pl-9 h-[34px]"
               />
             </div>
-            <PickerSelect
-              value={team ?? ""}
-              onValueChange={(value) => updateFilters({ team: value || undefined })}
-              options={[
-                { value: "", label: "All visible teamspaces" },
-                ...teams.map((item) => ({ value: item.handle, label: `Team: ${item.name}` })),
-              ]}
-              placeholder="Teamspace"
-              className="w-[210px]"
-              inputClassName="h-[34px]"
-            />
-            <UserSearchInput
-              value={publisherQuery}
-              onValueChange={(value) => {
-                setPublisherQuery(value);
-                if (namespace && value !== namespace && value !== `@${namespace}`) {
-                  updateFilters({ namespace: undefined });
-                }
-              }}
-              onSelect={(user) => {
-                if (!user.username) return;
-                setPublisherQuery(`@${user.username}`);
-                updateFilters({ namespace: user.username });
-              }}
-              placeholder="Publisher"
-              className="h-[34px] w-[220px]"
-            />
+            {isAuthenticated && (
+              <>
+                <PickerSelect
+                  value={team ?? ""}
+                  onValueChange={(value) => updateFilters({ team: value || undefined })}
+                  options={[
+                    { value: "", label: "All visible teamspaces" },
+                    ...teams.map((item) => ({ value: item.handle, label: `Team: ${item.name}` })),
+                  ]}
+                  placeholder="Teamspace"
+                  className="w-[210px]"
+                  inputClassName="h-[34px]"
+                />
+                <UserSearchInput
+                  value={publisherQuery}
+                  onValueChange={(value) => {
+                    setPublisherQuery(value);
+                    if (namespace && value !== namespace && value !== `@${namespace}`) {
+                      updateFilters({ namespace: undefined });
+                    }
+                  }}
+                  onSelect={(user) => {
+                    if (!user.username) return;
+                    setPublisherQuery(`@${user.username}`);
+                    updateFilters({ namespace: user.username });
+                  }}
+                  placeholder="Publisher"
+                  className="h-[34px] w-[220px]"
+                />
+              </>
+            )}
             <PickerSelect
               value={category ?? ""}
               onValueChange={(value) => updateFilters({ category: value || undefined })}
@@ -657,7 +672,7 @@ function AgentListContent() {
         </div>
 
         {/* My Drafts */}
-        {drafts.length > 0 && (
+        {isAuthenticated && drafts.length > 0 && (
           <div className="rounded-lg border border-border bg-card">
             <button
               type="button"
@@ -741,7 +756,7 @@ function AgentListContent() {
         )}
 
         {/* Archived */}
-        {archivedAgents.length > 0 && (
+        {isAuthenticated && archivedAgents.length > 0 && (
           <div className="rounded-lg border border-border bg-card">
             <button
               type="button"
@@ -798,7 +813,7 @@ function AgentListContent() {
         )}
 
         {/* Deleted */}
-        {deletedAgents.length > 0 && (
+        {isAuthenticated && deletedAgents.length > 0 && (
           <div className="rounded-lg border border-border bg-card">
             <button
               type="button"

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -7,7 +7,7 @@
 
 
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useState, useEffect, useCallback, useSyncExternalStore } from "react";
+import { useState, useEffect } from "react";
 import { Star, ArrowLeft, History, Loader2, ArrowDownToLine, Archive, ArchiveRestore, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -25,6 +25,7 @@ import {
   useWhoami,
 } from "@/hooks/use-api";
 import { getUserRole } from "@/lib/api";
+import { useOptionalAuth } from "@/hooks/use-auth";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import type { RegistryType } from "@/lib/api";
 import type { FeedbackItem, RegistryItem, ComponentVersionSummary } from "@/lib/types";
@@ -121,27 +122,18 @@ export default function ComponentDetailPage({
   const type = (componentType ?? search.type ?? "mcps") as RegistryType;
   const navigate = useNavigate();
   const singularType = type === "sandboxes" ? "sandbox" : type.replace(/s$/, "");
+  const { isAuthenticated } = useOptionalAuth();
   const { data: item, isLoading, isError, error, refetch } = useRegistryItem(type, id);
   const { data: feedbackItems, refetch: refetchFeedback } = useFeedback(singularType, id);
   const { data: feedbackSummary, refetch: refetchSummary } = useFeedbackSummary(id);
-  const { data: myReview } = useMyFeedback(singularType, id);
-  const { data: rawMetrics } = useRegistryMetrics(type, id);
+  const { data: myReview } = useMyFeedback(singularType, id, isAuthenticated);
+  const { data: rawMetrics } = useRegistryMetrics(type, id, isAuthenticated);
   const { data: versionsData, isLoading: versionsLoading } = useComponentVersions(type, id);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const { data: versionDetail } = useComponentVersionDetail(type, id, selectedVersion);
-  const { data: whoami } = useWhoami();
-  const { data: teams = [] } = useTeams();
+  const { data: whoami } = useWhoami(isAuthenticated);
+  const { data: teams = [] } = useTeams(isAuthenticated);
   const updateVisibility = useUpdateRegistryVisibility();
-
-  const storeSub = useCallback((cb: () => void) => {
-    window.addEventListener("storage", cb);
-    return () => window.removeEventListener("storage", cb);
-  }, []);
-  const isAuthenticated = useSyncExternalStore(
-    storeSub,
-    () => !!sessionStorage.getItem("observal_access_token"),
-    () => false,
-  );
   const canEdit = isAuthenticated && (item?.user_permission === "owner");
   const owningTeam = item?.team_id ? teams.find((team) => team.id === String(item.team_id)) : undefined;
   const personalTeam = teams.find((team) => team.is_personal && team.visibility === "private");
@@ -172,14 +164,22 @@ export default function ComponentDetailPage({
   // Co-authors
   const [coAuthors, setCoAuthors] = useState<CoAuthor[]>([]);
   useEffect(() => {
+    if (!isAuthenticated) {
+      setCoAuthors([]);
+      return;
+    }
+    const controller = new AbortController();
     const token = sessionStorage.getItem("observal_access_token");
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
-    fetch(`/api/v1/${type}/${id}/co-authors`, { headers })
+    fetch(`/api/v1/${type}/${id}/co-authors`, { headers, signal: controller.signal })
       .then((r) => (r.ok ? r.json() : []))
-      .then((data) => setCoAuthors(data))
+      .then((data) => {
+        if (!controller.signal.aborted) setCoAuthors(data);
+      })
       .catch(() => {});
-  }, [type, id]);
+    return () => controller.abort();
+  }, [type, id, isAuthenticated]);
 
   const versions = versionsData?.items ?? [];
   // VersionDropdown expects AgentVersionSummary shape; ComponentVersionSummary is compatible
@@ -258,7 +258,7 @@ export default function ComponentDetailPage({
 
   const avgRating = feedbackSummary?.average_rating;
   const totalReviews = feedbackSummary?.total_reviews ?? 0;
-  const metricsEntries: [string, string][] = rawMetrics && typeof rawMetrics === "object"
+  const metricsEntries: [string, string][] = isAuthenticated && rawMetrics && typeof rawMetrics === "object"
     ? Object.entries(rawMetrics as Record<string, unknown>).map(([k, v]) => [k, typeof v === "number" ? v.toLocaleString() : String(v ?? "")])
     : [];
 
@@ -431,7 +431,7 @@ export default function ComponentDetailPage({
                 ) : (
                   <div className="space-y-4">
                     {feedbackItems
-                      .filter((fb: FeedbackItem) => !myReview || fb.id !== myReview.id)
+                      .filter((fb: FeedbackItem) => !isAuthenticated || !myReview || fb.id !== myReview.id)
                       .map((fb: FeedbackItem) => (
                       <div key={fb.id} className="rounded-md border border-border p-4 space-y-2">
                         <div className="flex items-center justify-between">

--- a/web/src/pages/registry/components/index.tsx
+++ b/web/src/pages/registry/components/index.tsx
@@ -34,7 +34,7 @@ import {
   useCancelEdit,
   useTeams,
 } from "@/hooks/use-api";
-import { useAuthGuard } from "@/hooks/use-auth";
+import { useOptionalAuth } from "@/hooks/use-auth";
 import type { RegistryType } from "@/lib/api";
 import type { RegistryItem } from "@/lib/types";
 import {
@@ -192,8 +192,8 @@ function makeColumns(activeType: RegistryType): ColumnDef<RegistryItem>[] {
 export default function ComponentsPage() {
   const router = useRouter();
   const searchParams = useSearch({ from: "/_authed/components/" });
-  const { ready: authReady, role } = useAuthGuard();
-  const { data: teams = [] } = useTeams();
+  const { ready: authReady, role, isAuthenticated } = useOptionalAuth();
+  const { data: teams = [] } = useTeams(isAuthenticated);
   const activeType = searchParams.type ?? "mcps";
   const [search, setSearch] = useState(searchParams.search ?? "");
   const [debouncedSearch, setDebouncedSearch] = useState(searchParams.search ?? "");
@@ -231,10 +231,12 @@ export default function ComponentsPage() {
 
   const { data, isLoading, isError, error, refetch } = useRegistryList(activeType, registryFilters);
 
-  const { data: myItems } = useMyComponents(activeType);
+  const { data: myItems } = useMyComponents(activeType, isAuthenticated);
   const myDrafts = useMemo(
-    () => (myItems ?? []).filter((i) => ["draft", "pending", "rejected", "archived"].includes(i.status ?? "")),
-    [myItems],
+    () => isAuthenticated
+      ? (myItems ?? []).filter((i) => ["draft", "pending", "rejected", "archived"].includes(i.status ?? ""))
+      : [],
+    [isAuthenticated, myItems],
   );
 
   const submitMutation = useComponentSubmit(activeType);
@@ -347,33 +349,37 @@ export default function ComponentsPage() {
                 className="pl-9 h-9"
               />
             </div>
-            <PickerSelect
-              value={searchParams.team ?? ""}
-              onValueChange={(value) => updateFilters({ team: value || undefined })}
-              options={[
-                { value: "", label: "All visible teamspaces" },
-                ...teams.map((team) => ({ value: team.handle, label: `Team: ${team.name}` })),
-              ]}
-              placeholder="Teamspace"
-              className="w-[210px]"
-              inputClassName="h-9"
-            />
-            <UserSearchInput
-              value={publisherQuery}
-              onValueChange={(value) => {
-                setPublisherQuery(value);
-                if (searchParams.namespace && value !== searchParams.namespace && value !== `@${searchParams.namespace}`) {
-                  updateFilters({ namespace: undefined });
-                }
-              }}
-              onSelect={(user) => {
-                if (!user.username) return;
-                setPublisherQuery(`@${user.username}`);
-                updateFilters({ namespace: user.username });
-              }}
-              placeholder="Publisher"
-              className="h-9 w-[220px]"
-            />
+            {isAuthenticated && (
+              <>
+                <PickerSelect
+                  value={searchParams.team ?? ""}
+                  onValueChange={(value) => updateFilters({ team: value || undefined })}
+                  options={[
+                    { value: "", label: "All visible teamspaces" },
+                    ...teams.map((team) => ({ value: team.handle, label: `Team: ${team.name}` })),
+                  ]}
+                  placeholder="Teamspace"
+                  className="w-[210px]"
+                  inputClassName="h-9"
+                />
+                <UserSearchInput
+                  value={publisherQuery}
+                  onValueChange={(value) => {
+                    setPublisherQuery(value);
+                    if (searchParams.namespace && value !== searchParams.namespace && value !== `@${searchParams.namespace}`) {
+                      updateFilters({ namespace: undefined });
+                    }
+                  }}
+                  onSelect={(user) => {
+                    if (!user.username) return;
+                    setPublisherQuery(`@${user.username}`);
+                    updateFilters({ namespace: user.username });
+                  }}
+                  placeholder="Publisher"
+                  className="h-9 w-[220px]"
+                />
+              </>
+            )}
             {typeFilters.map((filter) => (
               <PickerSelect
                 key={filter.key}
@@ -633,7 +639,7 @@ export default function ComponentsPage() {
         )}
       </div>
 
-      <SubmitComponentDialog
+      {isAuthenticated && <SubmitComponentDialog
         key={editItem?.id ?? "new"}
         open={submitOpen}
         onOpenChange={(v) => {
@@ -674,7 +680,7 @@ export default function ComponentsPage() {
         }}
         isSubmitting={submitMutation.isPending || submitDraftMutation.isPending}
         isSavingDraft={saveDraftMutation.isPending || updateDraftMutation.isPending}
-      />
+      />}
     </>
   );
 }

--- a/web/src/pages/registry/home.tsx
+++ b/web/src/pages/registry/home.tsx
@@ -12,6 +12,7 @@ import {
   Bot,
   Search,
   Star,
+  Terminal,
 } from "lucide-react";
 import { PageHeader } from "@/components/layouts/page-header";
 import { RecommendedForYou } from "@/components/registry/recommended-for-you";
@@ -27,6 +28,7 @@ import {
   useTopAgents,
   useWhoami,
 } from "@/hooks/use-api";
+import { useOptionalAuth } from "@/hooks/use-auth";
 import { useDeploymentConfig } from "@/hooks/use-deployment-config";
 import { registryItemPath } from "@/lib/registry-name";
 import { compactNumber } from "@/lib/utils";
@@ -217,15 +219,17 @@ function WorkRow({
 export default function RegistryHome() {
   const [search, setSearch] = useState("");
   const router = useRouter();
-  const { data: whoami } = useWhoami();
+  const { isAuthenticated } = useOptionalAuth();
+  const { data: whoami } = useWhoami(isAuthenticated);
   const { brandingAppName } = useDeploymentConfig();
   const { data: sessions, isLoading: sessionsLoading } = useSessions2({
     days: 7,
     limit: 8,
     mine: true,
     refetchInterval: 30_000,
+    enabled: isAuthenticated,
   });
-  const { data: myAgents, isLoading: myAgentsLoading } = useMyAgents();
+  const { data: myAgents, isLoading: myAgentsLoading } = useMyAgents(isAuthenticated);
   const { data: topAgents, isLoading: topAgentsLoading } = useTopAgents(6);
   const {
     data: agents,
@@ -255,10 +259,11 @@ export default function RegistryHome() {
   const recentSessions = (sessions ?? []).slice(0, 4);
   const displayName =
     whoami?.name || whoami?.username || whoami?.email || "Welcome back";
-  const daySummary =
-    myAgentsLoading || sessionsLoading
+  const daySummary = isAuthenticated
+    ? myAgentsLoading || sessionsLoading
       ? "Loading your registry activity."
-      : `${workInProgress.length} registry item${workInProgress.length === 1 ? "" : "s"} need attention · ${(sessions ?? []).length} recent session${(sessions ?? []).length === 1 ? "" : "s"} captured.`;
+      : `${workInProgress.length} registry item${workInProgress.length === 1 ? "" : "s"} need attention · ${(sessions ?? []).length} recent session${(sessions ?? []).length === 1 ? "" : "s"} captured.`
+    : "Browse and install approved public agents and components without an account. Sign in when you are ready to publish or manage your own work.";
 
   function handleSearch(event: React.FormEvent) {
     event.preventDefault();
@@ -271,9 +276,52 @@ export default function RegistryHome() {
       <PageHeader title="Registry" />
 
       <div className="mx-auto w-full max-w-[90rem] space-y-8 px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
+        {!isAuthenticated && (
+          <section
+            aria-labelledby="guest-cli-title"
+            className="rounded-lg border border-primary-accent/25 bg-primary-accent/5 px-5 py-5 sm:px-6"
+          >
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-md bg-primary-accent/10 p-2 text-primary-accent">
+                <Terminal className="h-4 w-4" />
+              </div>
+              <div>
+                <h2 id="guest-cli-title" className="text-base font-semibold text-foreground">
+                  Use the public registry from your terminal
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                  No account or token is required for approved public content.
+                </p>
+              </div>
+            </div>
+            <ol className="mt-5 grid gap-4 text-sm md:grid-cols-3">
+              <li className="min-w-0">
+                <p className="mb-1.5 font-medium text-foreground">1. Install the CLI</p>
+                <code className="block overflow-x-auto whitespace-nowrap rounded-md bg-background px-3 py-2 font-mono text-xs text-foreground">
+                  uv tool install observal-cli
+                </code>
+              </li>
+              <li className="min-w-0">
+                <p className="mb-1.5 font-medium text-foreground">2. Find an agent</p>
+                <code className="block overflow-x-auto whitespace-nowrap rounded-md bg-background px-3 py-2 font-mono text-xs text-foreground">
+                  observal agent list
+                </code>
+              </li>
+              <li className="min-w-0">
+                <p className="mb-1.5 font-medium text-foreground">3. Pull it into your harness</p>
+                <code className="block overflow-x-auto whitespace-nowrap rounded-md bg-background px-3 py-2 font-mono text-xs text-foreground">
+                  observal pull namespace/agent --harness pi
+                </code>
+              </li>
+            </ol>
+          </section>
+        )}
+
         <section className="max-w-5xl">
           <h1 className="max-w-3xl text-balance text-2xl font-semibold tracking-[-0.03em] text-foreground sm:text-3xl">
-            {displayName}, here is your day in {brandingAppName || "Observal"}.
+            {isAuthenticated
+              ? `${displayName}, here is your day in ${brandingAppName || "Observal"}.`
+              : `Explore ${brandingAppName || "Observal"}'s public registry.`}
           </h1>
           <p className="mt-2 max-w-2xl text-base leading-7 text-muted-foreground">
             {daySummary}
@@ -330,45 +378,74 @@ export default function RegistryHome() {
             >
               Hooks
             </Link>
-            <Link
-              to="/teamspaces"
-              className="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-            >
-              Teamspaces
-            </Link>
+            {isAuthenticated && (
+              <Link
+                to="/teamspaces"
+                className="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Teamspaces
+              </Link>
+            )}
           </nav>
         </section>
 
         <div className="grid items-start gap-6 xl:grid-cols-[minmax(0,1fr)_21rem]">
-          <RecommendedForYou limit={3} />
+          {isAuthenticated ? (
+            <RecommendedForYou limit={3} />
+          ) : (
+            <section className="overflow-hidden rounded-md border border-border bg-card">
+              <PanelHeader
+                title="Public registry"
+                description="Approved building blocks you can use immediately."
+                action={
+                  <Button asChild size="sm">
+                    <Link to="/login">Sign in to contribute</Link>
+                  </Button>
+                }
+              />
+              {agentsLoading ? (
+                <div className="p-3"><TableSkeleton rows={3} cols={2} /></div>
+              ) : trustedAgents.length > 0 ? (
+                trustedAgents.slice(0, 3).map((agent) => <AvailableAgentRow key={agent.id} agent={agent} />)
+              ) : (
+                <p className="p-6 text-sm text-muted-foreground">Approved agents will appear here when the registry starts publishing.</p>
+              )}
+            </section>
+          )}
 
           <section className="overflow-hidden rounded-md border border-border bg-card">
             <PanelHeader
-              title="Your work"
-              description="Publishing and maintenance that needs you."
+              title={isAuthenticated ? "Your work" : "Start exploring"}
+              description={isAuthenticated ? "Publishing and maintenance that needs you." : "Browse the public catalog without signing in."}
             />
             <WorkRow
               href="/agents"
               icon={Bot}
               title={
-                myAgentsLoading
-                  ? "Loading your work"
-                  : workInProgress.length > 0
-                    ? `${workInProgress.length} item${workInProgress.length === 1 ? "" : "s"} need attention`
-                    : "Your agents are up to date"
+                isAuthenticated
+                  ? myAgentsLoading
+                    ? "Loading your work"
+                    : workInProgress.length > 0
+                      ? `${workInProgress.length} item${workInProgress.length === 1 ? "" : "s"} need attention`
+                      : "Your agents are up to date"
+                  : "Browse public agents"
               }
               description={
-                workInProgress.length > 0
-                  ? "Open drafts, pending reviews, and rejected submissions."
-                  : "Review published agents or start a new release."
+                isAuthenticated
+                  ? workInProgress.length > 0
+                    ? "Open drafts, pending reviews, and rejected submissions."
+                    : "Review published agents or start a new release."
+                  : "Find an approved agent and pull it into your harness."
               }
             />
-            <WorkRow
-              href="/agents/builder"
-              icon={Bot}
-              title="Build an agent"
-              description="Bundle components into a portable, versioned agent."
-            />
+            {isAuthenticated && (
+              <WorkRow
+                href="/agents/builder"
+                icon={Bot}
+                title="Build an agent"
+                description="Bundle components into a portable, versioned agent."
+              />
+            )}
             <WorkRow
               href="/components"
               icon={Blocks}
@@ -420,31 +497,37 @@ export default function RegistryHome() {
 
           <section className="overflow-hidden rounded-md border border-border bg-card">
             <PanelHeader
-              title="Recent execution"
-              description="Your latest captured coding sessions."
+              title={isAuthenticated ? "Recent execution" : "More public agents"}
+              description={isAuthenticated ? "Your latest captured coding sessions." : "Recently approved agents from the public registry."}
               action={
                 <Link
-                  to="/traces"
+                  to={isAuthenticated ? "/traces" : "/agents"}
                   className="shrink-0 text-sm font-medium text-primary-accent underline-offset-4 hover:underline"
                 >
-                  All traces
+                  {isAuthenticated ? "All traces" : "All agents"}
                 </Link>
               }
             />
-            {sessionsLoading ? (
-              <div className="p-3">
-                <TableSkeleton rows={4} cols={2} />
-              </div>
-            ) : recentSessions.length === 0 ? (
-              <div className="flex gap-3 p-5 text-sm leading-6 text-muted-foreground">
-                <Activity className="mt-1 h-4 w-4 shrink-0" />
-                Enable telemetry in a supported harness to connect registry assets
-                with execution evidence.
-              </div>
+            {isAuthenticated ? (
+              sessionsLoading ? (
+                <div className="p-3">
+                  <TableSkeleton rows={4} cols={2} />
+                </div>
+              ) : recentSessions.length === 0 ? (
+                <div className="flex gap-3 p-5 text-sm leading-6 text-muted-foreground">
+                  <Activity className="mt-1 h-4 w-4 shrink-0" />
+                  Enable telemetry in a supported harness to connect registry assets
+                  with execution evidence.
+                </div>
+              ) : (
+                recentSessions.map((session) => (
+                  <SessionRow key={session.session_id} session={session} />
+                ))
+              )
+            ) : agentsLoading ? (
+              <div className="p-3"><TableSkeleton rows={4} cols={2} /></div>
             ) : (
-              recentSessions.map((session) => (
-                <SessionRow key={session.session_id} session={session} />
-              ))
+              approvedAgents.slice(5, 9).map((agent) => <AvailableAgentRow key={agent.id} agent={agent} />)
             )}
           </section>
         </div>

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createRootRoute, Outlet } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "@/lib/theme";
 import { makeQueryClient } from "@/lib/query-client";
@@ -11,8 +11,34 @@ import { ErrorBoundary } from "@/components/shared/error-boundary";
 import { VersionMismatchBanner } from "@/components/shared/version-mismatch-banner";
 import "@/app.css";
 
+function subscribeToAuthChanges(callback: () => void) {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
+function getAuthTokenSnapshot() {
+  return typeof window === "undefined"
+    ? ""
+    : sessionStorage.getItem("observal_access_token") ?? "";
+}
+
 function RootComponent() {
   const [queryClient] = useState(makeQueryClient);
+  const authToken = useSyncExternalStore(subscribeToAuthChanges, getAuthTokenSnapshot, () => "");
+  const previousAuthToken = useRef(authToken);
+
+  useEffect(() => {
+    if (previousAuthToken.current !== authToken) {
+      queryClient.clear();
+      previousAuthToken.current = authToken;
+    }
+  }, [authToken, queryClient]);
+
+  useEffect(() => {
+    const clearAccountData = () => queryClient.clear();
+    window.addEventListener("observal:session-cleared", clearAccountData);
+    return () => window.removeEventListener("observal:session-cleared", clearAccountData);
+  }, [queryClient]);
 
   return (
     <ErrorBoundary>

--- a/web/src/routes/_authed.tsx
+++ b/web/src/routes/_authed.tsx
@@ -1,28 +1,51 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
 import { Suspense } from "react";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { RegistrySidebar } from "@/components/nav/registry-sidebar";
 import { Toaster } from "@/components/ui/sonner";
-import { AuthGuard } from "@/components/layouts/auth-guard";
+import { AuthGuard, OptionalAuthGuard } from "@/components/layouts/auth-guard";
 import { HelpProvider } from "@/components/wiki/help-context";
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
+import { isPublicRegistryPath } from "@/lib/public-registry";
+
+function AppShell() {
+  return (
+    <HelpProvider>
+      <SidebarProvider>
+        <RegistrySidebar />
+        <SidebarInset>
+          <Suspense fallback={<div className="flex h-screen w-full items-center justify-center" />}>
+            <Outlet />
+          </Suspense>
+        </SidebarInset>
+        <Toaster visibleToasts={1} />
+      </SidebarProvider>
+    </HelpProvider>
+  );
+}
 
 function AuthedLayout() {
+  const { pathname } = useLocation();
+  const { publicRegistryEnabled, loading } = useDeploymentConfig();
+
+  if (loading) {
+    return <div className="flex h-screen w-full items-center justify-center" />;
+  }
+
+  if (publicRegistryEnabled && isPublicRegistryPath(pathname)) {
+    return (
+      <OptionalAuthGuard>
+        <AppShell />
+      </OptionalAuthGuard>
+    );
+  }
+
   return (
     <AuthGuard>
-      <HelpProvider>
-        <SidebarProvider>
-          <RegistrySidebar />
-          <SidebarInset>
-            <Suspense fallback={<div className="flex h-screen w-full items-center justify-center" />}>
-              <Outlet />
-            </Suspense>
-          </SidebarInset>
-          <Toaster visibleToasts={1} />
-        </SidebarProvider>
-      </HelpProvider>
+      <AppShell />
     </AuthGuard>
   );
 }


### PR DESCRIPTION
## Purpose / Description
  Allow visitors to browse and install approved public Observal registry content without signing in. Authentication is
 still required for publishing, editing, private content, telemetry, feedback, and administration.

   ## Approach
   - Added a database-backed `deployment.public_registry_enabled` setting, defaulted to off.
   - Added a Public Registry toggle to the admin Settings page.
   - Added optional authentication for approved public agents, components, versions, reviews, leaderboards, prompt
 rendering, and install endpoints.
   - Kept private resources and all write operations protected by authentication and role checks.
   - Added a signed-out registry experience with public navigation and sign-in prompts.
   - Updated the CLI to use `https://public.observal.io` by default for public reads and installs while continuing to
 require authentication for writes.
   - Added coverage for the public access gate and anonymous CLI requests.

   ## How Has This Been Tested?
   - `uv run ruff check .`
   - `uv run ruff format --check .`
   - `pnpm typecheck`
   - `pnpm lint`
   - `pnpm build`
   - `uv run pytest -q observal_cli/tests tests/test_pull_and_agent_cli.py tests/test_harness_config_e2e.py
 tests/test_cmd_prompt.py` with 260 passing tests
   - Server test suite excluding the existing Goose session test file: 5453 passed and 21 skipped
   - Live browser checks against `https://public.observal.io` for the public home, agent list, agent detail, component
 list, component detail, and protected route redirect
   - Live CLI checks without credentials for agent list, agent show, skill list, skill install, agent pull dry run, and
 a real agent pull into a temporary directory
   - Confirmed anonymous publish requests still return HTTP 401

   ## Learning
   The registry API already had visibility helpers for anonymous callers, so the implementation builds on those
 controls instead of introducing a shared guest account.

   ## Checklist
   - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
   - [x] You have commented your code, particularly in hard-to-understand areas
   - [x] You have performed a self-review of your own code
   - [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

   ## AI Assistance
   - [x] Yes (Pi coding agent)
   - [x] Was the generated code manually reviewed and tested?
   
   
<img width="1102" height="986" alt="Screenshot 2026-09-11 170330" src="https://github.com/user-attachments/assets/3870ad72-8834-4ad2-b5dd-acbfab351674" />



<img width="2480" height="1290" alt="Screenshot 2026-09-11 182918" src="https://github.com/user-attachments/assets/7179d866-6d9b-42d3-8983-2202f0bd5516" />
a78-e50f596c5a2e" />

   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public registry access can be enabled for anonymous browsing, viewing, rendering, and installing approved content.
  * Added an administrator toggle to control public registry availability, disabled by default.
  * Unauthenticated visitors now see an Explore experience and sign-in prompts for contributor features.
  * CLI read and installation commands can use the public server without login.
* **Bug Fixes**
  * Authentication-dependent requests are no longer triggered for signed-out visitors.
  * Anonymous activity no longer creates user-linked download records.
  * Public version totals now exclude inaccessible pending or rejected versions.
  * Signing out now clears account-specific cached data immediately.
  * Prompt rendering now preserves backslashes and replacement text literally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->